### PR TITLE
Fix bug label check when building release notes

### DIFF
--- a/update-changelog/ReleaseNotesBuilder.js
+++ b/update-changelog/ReleaseNotesBuilder.js
@@ -1,9 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ReleaseNotesBuilder = exports.ENTERPRISE_LABEL = exports.BREAKING_SECTION_START = exports.BREAKING_CHANGE_LABEL = exports.GRAFANA_UI_LABEL = exports.GRAFANA_TOOLKIT_LABEL = exports.CHANGELOG_LABEL = void 0;
+exports.ReleaseNotesBuilder = exports.ENTERPRISE_LABEL = exports.BREAKING_SECTION_START = exports.BREAKING_CHANGE_LABEL = exports.GRAFANA_UI_LABEL = exports.GRAFANA_TOOLKIT_LABEL = exports.BUG_LABEL = exports.CHANGELOG_LABEL = void 0;
 const lodash_1 = require("lodash");
 const utils_1 = require("../common/utils");
 exports.CHANGELOG_LABEL = 'add to changelog';
+exports.BUG_LABEL = 'type/bug';
 exports.GRAFANA_TOOLKIT_LABEL = 'area/grafana/toolkit';
 exports.GRAFANA_UI_LABEL = 'area/grafana/ui';
 exports.BREAKING_CHANGE_LABEL = 'breaking change';
@@ -183,7 +184,7 @@ function isBugFix(item) {
     if (item.title.match(/fix|fixes/i)) {
         return true;
     }
-    if (item.labels.find((label) => label.name === 'type/bug')) {
+    if (item.labels.find((label) => label === exports.BUG_LABEL)) {
         return true;
     }
     return false;

--- a/update-changelog/ReleaseNotesBuilder.test.ts
+++ b/update-changelog/ReleaseNotesBuilder.test.ts
@@ -4,11 +4,11 @@ import { OctoKit } from '../api/octokit'
 import { Testbed, TestbedIssueConstructorArgs } from '../api/testbed'
 import {
 	ReleaseNotesBuilder,
-	CHANGELOG_LABEL,
-	GRAFANA_UI_LABEL,
 	BREAKING_CHANGE_LABEL,
 	BREAKING_SECTION_START,
-	ENTERPRISE_LABEL,
+	BUG_LABEL,
+	CHANGELOG_LABEL,
+	GRAFANA_UI_LABEL,
 } from './ReleaseNotesBuilder'
 
 describe('ReleaseNotesBuilder', () => {
@@ -30,6 +30,12 @@ describe('ReleaseNotesBuilder', () => {
 					title: 'Login: New feature',
 				},
 				labels: [CHANGELOG_LABEL],
+			},
+			{
+				issue: {
+					title: 'Auth: Prevent errors from happening',
+				},
+				labels: [CHANGELOG_LABEL, BUG_LABEL],
 			},
 			{
 				issue: {

--- a/update-changelog/ReleaseNotesBuilder.ts
+++ b/update-changelog/ReleaseNotesBuilder.ts
@@ -3,6 +3,7 @@ import { sortBy, difference } from 'lodash'
 import { splitStringIntoLines } from '../common/utils'
 
 export const CHANGELOG_LABEL = 'add to changelog'
+export const BUG_LABEL = 'type/bug'
 export const GRAFANA_TOOLKIT_LABEL = 'area/grafana/toolkit'
 export const GRAFANA_UI_LABEL = 'area/grafana/ui'
 export const BREAKING_CHANGE_LABEL = 'breaking change'
@@ -228,7 +229,7 @@ function isBugFix(item: Issue) {
 	if (item.title.match(/fix|fixes/i)) {
 		return true
 	}
-	if (item.labels.find((label: any) => label.name === 'type/bug')) {
+	if (item.labels.find((label: any) => label === BUG_LABEL)) {
 		return true
 	}
 	return false

--- a/update-changelog/ReleaseNotesBuilder.ts
+++ b/update-changelog/ReleaseNotesBuilder.ts
@@ -229,7 +229,7 @@ function isBugFix(item: Issue) {
 	if (item.title.match(/fix|fixes/i)) {
 		return true
 	}
-	if (item.labels.find((label: any) => label === BUG_LABEL)) {
+	if (item.labels.find((label: string) => label === BUG_LABEL)) {
 		return true
 	}
 	return false

--- a/update-changelog/__snapshots__/ReleaseNotesBuilder.test.ts.snap
+++ b/update-changelog/__snapshots__/ReleaseNotesBuilder.test.ts.snap
@@ -16,6 +16,8 @@ exports[`ReleaseNotesBuilder Should build correct release notes 1`] = `
 * **API**: Fixed api issue. (Enterprise)
 * **Alerting**: Fixed really bad issue. [#1](https://github.com/grafana/grafana/issues/1)
 * **Alerting**: Fixed really bad issue. (Enterprise)
+* **Auth**: Prevent errors from happening. [#1](https://github.com/grafana/grafana/issues/1)
+* **Auth**: Prevent errors from happening. (Enterprise)
 
 ### Breaking changes
 

--- a/update-changelog/index.js
+++ b/update-changelog/index.js
@@ -28,7 +28,7 @@ class UpdateChangelog extends Action_1.Action {
         const fileUpdater = new FileUpdater_1.FileUpdater();
         const builder = new ReleaseNotesBuilder_1.ReleaseNotesBuilder(octokit, version);
         const changelogFile = './CHANGELOG.md';
-        const branchName = 'update-changelog-and-relase-notes';
+        const branchName = 'update-changelog-and-release-notes';
         const releaseNotes = await builder.buildReleaseNotes({ useDocsHeader: false });
         const title = `ReleaseNotes: Updated changelog and release notes for ${version}`;
         // Update main changelog


### PR DESCRIPTION
It seems labels are just given as strings through the API

```
export interface Issue {
	labels: string[]
...
```