### PR TITLE
Prettier: Update Changelog formatting to use - instead of *

### DIFF
--- a/update-changelog/ReleaseNotesBuilder.js
+++ b/update-changelog/ReleaseNotesBuilder.js
@@ -164,16 +164,16 @@ class ReleaseNotesBuilder {
             title = title.slice(0, -1);
         }
         if (issueHasLabel(item, exports.ENTERPRISE_LABEL)) {
-            markdown += `* ${title}. (Enterprise)`;
+            markdown += `- ${title}. (Enterprise)`;
             return markdown;
         }
         if (item.isPullRequest) {
-            markdown += '* ' + title + '.';
+            markdown += '- ' + title + '.';
             markdown += ` [#${item.number}](${githubGrafanaUrl}/pull/${item.number})`;
             markdown += `, [@${item.author.name}](https://github.com/${item.author.name})`;
         }
         else {
-            markdown += '* ' + title + '.';
+            markdown += '- ' + title + '.';
             markdown += ` ${linkToIssue(item)}`;
         }
         return markdown;

--- a/update-changelog/ReleaseNotesBuilder.test.ts
+++ b/update-changelog/ReleaseNotesBuilder.test.ts
@@ -133,8 +133,8 @@ Variables have been deprecated`,
 
 		### Bug fixes
 
-		* **Alerting:** Fixed really bad issue. [#1](https://github.com/grafana/grafana/issues/1)
-		* **Alerting:** Fixed really bad issue. (Enterprise)
+		- **Alerting:** Fixed really bad issue. [#1](https://github.com/grafana/grafana/issues/1)
+		- **Alerting:** Fixed really bad issue. (Enterprise)
 		"
 	`)
 

--- a/update-changelog/ReleaseNotesBuilder.ts
+++ b/update-changelog/ReleaseNotesBuilder.ts
@@ -207,16 +207,16 @@ export class ReleaseNotesBuilder {
 		}
 
 		if (issueHasLabel(item, ENTERPRISE_LABEL)) {
-			markdown += `* ${title}. (Enterprise)`
+			markdown += `- ${title}. (Enterprise)`
 			return markdown
 		}
 
 		if (item.isPullRequest) {
-			markdown += '* ' + title + '.'
+			markdown += '- ' + title + '.'
 			markdown += ` [#${item.number}](${githubGrafanaUrl}/pull/${item.number})`
 			markdown += `, [@${item.author.name}](https://github.com/${item.author.name})`
 		} else {
-			markdown += '* ' + title + '.'
+			markdown += '- ' + title + '.'
 			markdown += ` ${linkToIssue(item)}`
 		}
 

--- a/update-changelog/__snapshots__/ReleaseNotesBuilder.test.ts.snap
+++ b/update-changelog/__snapshots__/ReleaseNotesBuilder.test.ts.snap
@@ -5,21 +5,21 @@ exports[`ReleaseNotesBuilder Should build correct release notes 1`] = `
 
 ### Features and enhancements
 
-* **Dashboard:** Issue with deprecation notice. [#1](https://github.com/grafana/grafana/pull/1), [@torkelo](https://github.com/torkelo)
-* **Dashboard:** Issue with deprecation notice. (Enterprise)
-* **Login:** New feature. [#1](https://github.com/grafana/grafana/issues/1)
-* **Login:** New feature. (Enterprise)
-* **Variables:** Variables deprecated. [#1](https://github.com/grafana/grafana/pull/1), [@torkelo](https://github.com/torkelo)
-* **Variables:** Variables deprecated. (Enterprise)
+- **Dashboard:** Issue with deprecation notice. [#1](https://github.com/grafana/grafana/pull/1), [@torkelo](https://github.com/torkelo)
+- **Dashboard:** Issue with deprecation notice. (Enterprise)
+- **Login:** New feature. [#1](https://github.com/grafana/grafana/issues/1)
+- **Login:** New feature. (Enterprise)
+- **Variables:** Variables deprecated. [#1](https://github.com/grafana/grafana/pull/1), [@torkelo](https://github.com/torkelo)
+- **Variables:** Variables deprecated. (Enterprise)
 
 ### Bug fixes
 
-* **API:** Fixed api issue. [#1](https://github.com/grafana/grafana/pull/1), [@torkelo](https://github.com/torkelo)
-* **API:** Fixed api issue. (Enterprise)
-* **Alerting:** Fixed really bad issue. [#1](https://github.com/grafana/grafana/issues/1)
-* **Alerting:** Fixed really bad issue. (Enterprise)
-* **Auth:** Prevent errors from happening. [#1](https://github.com/grafana/grafana/issues/1)
-* **Auth:** Prevent errors from happening. (Enterprise)
+- **API:** Fixed api issue. [#1](https://github.com/grafana/grafana/pull/1), [@torkelo](https://github.com/torkelo)
+- **API:** Fixed api issue. (Enterprise)
+- **Alerting:** Fixed really bad issue. [#1](https://github.com/grafana/grafana/issues/1)
+- **Alerting:** Fixed really bad issue. (Enterprise)
+- **Auth:** Prevent errors from happening. [#1](https://github.com/grafana/grafana/issues/1)
+- **Auth:** Prevent errors from happening. (Enterprise)
 
 ### Breaking changes
 
@@ -35,7 +35,7 @@ Variables have been deprecated Issue [#1](https://github.com/grafana/grafana/iss
 
 ### Plugin development fixes & changes
 
-* **Button:** Changed prop name for button. [#1](https://github.com/grafana/grafana/pull/1), [@torkelo](https://github.com/torkelo)
-* **Button:** Changed prop name for button. (Enterprise)
+- **Button:** Changed prop name for button. [#1](https://github.com/grafana/grafana/pull/1), [@torkelo](https://github.com/torkelo)
+- **Button:** Changed prop name for button. (Enterprise)
 "
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -730,6 +730,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/braces@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.1.tgz#5a284d193cfc61abb2e5a50d36ebbc50d942a32b"
+  integrity sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==
+
 "@types/chai@^4.2.10":
   version "4.2.14"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
@@ -790,6 +795,13 @@
   version "4.14.165"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
   integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+
+"@types/micromatch@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.2.tgz#ce29c8b166a73bf980a5727b1e4a4d099965151d"
+  integrity sha512-oqXqVb0ci19GtH0vOA/U2TmHTcRY9kuZl4mqUxe0QmJAlIW13kzhuK5pi1i9+ngav8FjpSb9FVS/GE00GLX1VA==
+  dependencies:
+    "@types/braces" "*"
 
 "@types/minimist@^1.2.0":
   version "1.2.1"


### PR DESCRIPTION
**What happened:** 

A couple of weeks ago we [introduced](https://github.com/grafana/grafana/pull/37616) the ability to prettify md files on `lint-staged` in the Grafana project. Today, after resolving conflicts between one of my branches and the main branch (That had the latest release v8.1.2), we noticed some `md` files [changed](https://github.com/grafana/grafana/pull/37741/files/602f3d363ea44ff92da1229f54468e00150d2788#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8), they were automatically formatted from using `*` to `-` in unordered lists.

Why they were automatically formatted? This is because the code to generate our CHANGELOG and release notes is using the old prettier format for unordered list `*`, and after prettier version 2 unordered lists are now formatted to`-`. I found a GitHub [discussion](https://github.com/prettier/prettier/issues/5308) that was talking about this.

**What is your PR fixing:** 

My PR is fixing this problem, it means for the future unordered list in the changelog and release notes will be using `-` instead of `*`, and we will not experience issues on the grafana project.

**Anything else we need to know?:** 

I am lacking some context in this repo, or if we are using this changelog command action in other repositories, or if my change had side effects 😅 


