### PR TITLE
chore(bump-version): add yarn.lock rebuild

### DIFF
--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -39,8 +39,13 @@ class BumpVersion extends Action_1.Action {
             '--exact',
             '--yes',
         ]);
-        //regenerate yarn.lock file
-        await exec_1.exec('yarn');
+        try {
+            //regenerate yarn.lock file
+            await exec_1.exec('yarn');
+        }
+        catch (e) {
+            console.error('yarn failed', e);
+        }
         await git('commit', '-am', `"Release: Updated versions in package to ${version}"`);
         // push
         await git('push', '--set-upstream', 'origin', prBranch);

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -46,7 +46,7 @@ class BumpVersion extends Action_1.Action {
         await git('push', '--set-upstream', 'origin', prBranch);
         const body = `Executed:\n
 npm version ${version} --no-git-tag-version\n
-npx lerna version ${version} --no-push --not-git-tag-version --force-publish --exact --yes
+npx lerna version ${version} --no-push --no-git-tag-version --force-publish --exact --yes
 yarn
 `;
         await octokit.octokit.pulls.create({

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -39,12 +39,15 @@ class BumpVersion extends Action_1.Action {
             '--exact',
             '--yes',
         ]);
+        //regenerate yarn.lock file
+        await exec_1.exec('yarn');
         await git('commit', '-am', `"Release: Updated versions in package to ${version}"`);
         // push
         await git('push', '--set-upstream', 'origin', prBranch);
         const body = `Executed:\n
 npm version ${version} --no-git-tag-version\n
 npx lerna version ${version} --no-push --not-git-tag-version --force-publish --exact --yes
+yarn
 `;
         await octokit.octokit.pulls.create({
             base,

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -55,7 +55,7 @@ class BumpVersion extends Action {
 
 		const body = `Executed:\n
 npm version ${version} --no-git-tag-version\n
-npx lerna version ${version} --no-push --not-git-tag-version --force-publish --exact --yes
+npx lerna version ${version} --no-push --no-git-tag-version --force-publish --exact --yes
 yarn
 `
 		await octokit.octokit.pulls.create({

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -45,8 +45,12 @@ class BumpVersion extends Action {
 			'--exact',
 			'--yes',
 		])
-		//regenerate yarn.lock file
-		await exec('yarn')
+		try {
+			//regenerate yarn.lock file
+			await exec('yarn')
+		} catch (e) {
+			console.error('yarn failed', e)
+		}
 
 		await git('commit', '-am', `"Release: Updated versions in package to ${version}"`)
 

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -45,6 +45,8 @@ class BumpVersion extends Action {
 			'--exact',
 			'--yes',
 		])
+		//regenerate yarn.lock file
+		await exec('yarn')
 
 		await git('commit', '-am', `"Release: Updated versions in package to ${version}"`)
 
@@ -54,6 +56,7 @@ class BumpVersion extends Action {
 		const body = `Executed:\n
 npm version ${version} --no-git-tag-version\n
 npx lerna version ${version} --no-push --not-git-tag-version --force-publish --exact --yes
+yarn
 `
 		await octokit.octokit.pulls.create({
 			base,


### PR DESCRIPTION
**Why?**
We have to regenerate `yarn.lock` file every time we bump version for release. It was previously done [manually](https://github.com/grafana/grafana/pull/42297/commits/1234ecb370796d7e4191ceb22f6345fdd596e40f). This PR automates it.

**Additional changes**
- Fixed type in output of grot

**How to test**
?


Fixes #37 