### PR TITLE
set YARN_ENABLE_IMMUTABLE_INSTALLS to false for generating yarn.lock

### DIFF
--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -41,7 +41,7 @@ class BumpVersion extends Action_1.Action {
         ]);
         try {
             //regenerate yarn.lock file
-            await (0, exec_1.exec)('yarn');
+            await (0, exec_1.exec)('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn');
         }
         catch (e) {
             console.error('yarn failed', e);

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -47,7 +47,7 @@ class BumpVersion extends Action {
 		])
 		try {
 			//regenerate yarn.lock file
-			await exec('yarn')
+			await exec('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn')
 		} catch (e) {
 			console.error('yarn failed', e)
 		}


### PR DESCRIPTION
Fixes #37 

yarn seems to be [failing](https://github.com/grafana/grafana/runs/4455819488?check_suite_focus=true#step:11:244) when running in grafana main repo, this should make it work (hopefully)