### PR TITLE
Add support for old projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Type: `label`
 - `name`: defines which label to match on
 - `addToProject` - an object that is required when the `action` is `addToProject` and is optional otherwise.
 - `addToProject.url`: Absolute url of the project, the project `id` will be parsed.
+- `addToProject.column`: Column name to add the issues to, required for old type of projects
 
 **Syntax**:
 ```
@@ -19,7 +20,8 @@ Type: `label`
     "name": "plugins",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/76"
+      "url": "https://github.com/orgs/grafana/projects/76",
+      "column": "To Do"
     }
   }
 ```

--- a/api/api.js
+++ b/api/api.js
@@ -4,4 +4,10 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.projectType = void 0;
+var projectType;
+(function (projectType) {
+    projectType[projectType["Project"] = 0] = "Project";
+    projectType[projectType["ProjectNext"] = 1] = "ProjectNext";
+})(projectType = exports.projectType || (exports.projectType = {}));
 //# sourceMappingURL=api.js.map

--- a/api/api.ts
+++ b/api/api.ts
@@ -24,9 +24,9 @@ export interface GitHub {
 
 	isUserMemberOfOrganization(org: string, username: string): Promise<boolean>
 
-	getProjectNodeId(projectId: number, org?: string): Promise<string | undefined>
+	getProject(projectId: number, org?: string, columnName?: string): Promise<ProjectAndColumnIds | undefined>
 
-	addIssueToProject(project: number, issue: Issue, org?: string): Promise<void>
+	addIssueToProject(project: number, issue: Issue, org?: string, columnName?: string): Promise<void>
 }
 
 export interface GitHubIssue extends GitHub {
@@ -118,4 +118,15 @@ export interface Milestone {
 	closed_at: string | null
 	number: number
 	title: string
+}
+
+export enum projectType {
+	Project,
+	ProjectNext,
+}
+
+export interface ProjectAndColumnIds {
+	columnNodeId?: string
+	projectNodeId: string
+	projectType: projectType
 }

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -219,7 +219,7 @@ class OctoKit {
         }
     }
     async getProject(projectId, org, columnName) {
-        console.debug('Running getProjectNodeId for project ' + projectId);
+        console.debug('Running getProject for project ' + projectId);
         try {
             const result = (await this._octokitGraphQL({
                 query: `query getProjectNodeId($org: String!, $projectId: Int!) {
@@ -280,6 +280,7 @@ class OctoKit {
         return undefined;
     }
     async addIssueToProjectOld(projectColumnId, issueNodeId) {
+        console.log('Running addIssueToProjectOld with: projectColumnId: ', projectColumnId, ' issueNodeId: ', issueNodeId);
         const mutation = `mutation addProjectCard($projectColumnId: String!, $issueNodeId: String!) {				
 			addProjectCard(input: {projectColumnId: $projectColumnId, contentId: $issueNodeId) {
 				cardEdge {
@@ -296,6 +297,7 @@ class OctoKit {
         });
     }
     async addIssueToProjectNext(projectNodeId, issueNodeId) {
+        console.log('Running addIssueToProjectNext with: projectNodeId: ', projectNodeId, ' issueNodeId: ', issueNodeId);
         const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -282,7 +282,7 @@ class OctoKit {
     async addIssueToProjectOld(projectColumnId, issueNodeId) {
         console.log('Running addIssueToProjectOld with: projectColumnId: ', projectColumnId, ' issueNodeId: ', issueNodeId);
         const mutation = `mutation addProjectCard($projectColumnId: String!, $issueNodeId: String!) {				
-			addProjectCard(input: {projectColumnId: $projectColumnId, contentId: $issueNodeId) {
+			addProjectCard(input: {projectColumnId: $projectColumnId, contentId: $issueNodeId}) {
 				cardEdge {
 					node {
 					  id

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -258,7 +258,7 @@ export class OctoKit implements GitHub {
 		org: string,
 		columnName?: string,
 	): Promise<ProjectAndColumnIds | undefined> {
-		console.debug('Running getProjectNodeId for project ' + projectId)
+		console.debug('Running getProject for project ' + projectId)
 
 		try {
 			const result = (await this._octokitGraphQL({
@@ -321,6 +321,12 @@ export class OctoKit implements GitHub {
 	}
 
 	protected async addIssueToProjectOld(projectColumnId: string, issueNodeId: string) {
+		console.log(
+			'Running addIssueToProjectOld with: projectColumnId: ',
+			projectColumnId,
+			' issueNodeId: ',
+			issueNodeId,
+		)
 		const mutation = `mutation addProjectCard($projectColumnId: String!, $issueNodeId: String!) {				
 			addProjectCard(input: {projectColumnId: $projectColumnId, contentId: $issueNodeId) {
 				cardEdge {
@@ -338,6 +344,13 @@ export class OctoKit implements GitHub {
 	}
 
 	protected async addIssueToProjectNext(projectNodeId: string, issueNodeId: string) {
+		console.log(
+			'Running addIssueToProjectNext with: projectNodeId: ',
+			projectNodeId,
+			' issueNodeId: ',
+			issueNodeId,
+		)
+
 		const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -328,7 +328,7 @@ export class OctoKit implements GitHub {
 			issueNodeId,
 		)
 		const mutation = `mutation addProjectCard($projectColumnId: String!, $issueNodeId: String!) {				
-			addProjectCard(input: {projectColumnId: $projectColumnId, contentId: $issueNodeId) {
+			addProjectCard(input: {projectColumnId: $projectColumnId, contentId: $issueNodeId}) {
 				cardEdge {
 					node {
 					  id

--- a/api/testbed.js
+++ b/api/testbed.js
@@ -5,6 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.TestbedIssue = exports.Testbed = void 0;
+const api_1 = require("./api");
 class Testbed {
     constructor(config) {
         this.config = {
@@ -60,10 +61,14 @@ class Testbed {
     async isUserMemberOfOrganization(org, username) {
         return this.config.userMemberOfOrganization;
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async getProjectNodeId(_projectId, _org) {
-        return this.config.projectNodeId;
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    async getProject(_projectId, _org, _columnName) {
+        return {
+            projectNodeId: this.config.projectNodeId ?? 'TESTPROJECTID',
+            projectType: api_1.projectType.ProjectNext,
+        };
     }
+    /* eslint-enable @typescript-eslint/no-unused-vars */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async addIssueToProject(_project, _issue, org) {
         // pass...

--- a/api/testbed.ts
+++ b/api/testbed.ts
@@ -3,7 +3,17 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Comment, GitHub, GitHubIssue, Issue, Milestone, Query, User } from './api'
+import {
+	Comment,
+	GitHub,
+	GitHubIssue,
+	Issue,
+	Milestone,
+	ProjectAndColumnIds,
+	projectType,
+	Query,
+	User,
+} from './api'
 
 type TestbedConfig = {
 	globalLabels: string[]
@@ -88,10 +98,18 @@ export class Testbed implements GitHub {
 		return this.config.userMemberOfOrganization
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	async getProjectNodeId(_projectId: number, _org?: string): Promise<string | undefined> {
-		return this.config.projectNodeId
+	/* eslint-disable @typescript-eslint/no-unused-vars */
+	async getProject(
+		_projectId: number,
+		_org?: string,
+		_columnName?: string,
+	): Promise<ProjectAndColumnIds | undefined> {
+		return {
+			projectNodeId: this.config.projectNodeId ?? 'TESTPROJECTID',
+			projectType: projectType.ProjectNext,
+		}
 	}
+	/* eslint-enable @typescript-eslint/no-unused-vars */
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async addIssueToProject(_project: number, _issue: Issue, org?: string): Promise<void> {

--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -132,7 +132,7 @@ class Commands {
             issue.labels.includes(command.name)) {
             const projectId = (0, utils_1.getProjectIdFromUrl)(command.addToProject.url);
             if (projectId) {
-                tasks.push(this.github.addIssueToProject(projectId, issue));
+                tasks.push(this.github.addIssueToProject(projectId, issue, command.addToProject.org, command.addToProject.column));
             }
             else {
                 console.debug('Could not parse project id from the provided URL', command.addToProject.url);

--- a/commands/Commands.test.ts
+++ b/commands/Commands.test.ts
@@ -514,8 +514,8 @@ describe('Commands', () => {
 			// arrange
 			const testProjectUrl = 'https://github.com/orgs/grafana/projects/76'
 			const testProjectId = 76
-			const testOrgName = 'testOrg'
 			const testLabel = 'plugins-platform'
+			const testColumnName = 'To Do'
 			const testbed = new TestbedIssue(
 				{
 					writers: ['JacksonKearl'],
@@ -535,15 +535,20 @@ describe('Commands', () => {
 					action: 'addToProject',
 					addToProject: {
 						url: testProjectUrl,
+						column: testColumnName,
 					},
-					org: testOrgName,
 					name: testLabel,
 				},
 			]
 			await new Commands(testbed, commands, { label: testLabel }).run()
 
 			// assert
-			jestExpect(spyAddIssueToProject).toHaveBeenCalledWith(testProjectId, await testbed.getIssue())
+			jestExpect(spyAddIssueToProject).toHaveBeenCalledWith(
+				testProjectId,
+				await testbed.getIssue(),
+				undefined,
+				testColumnName,
+			)
 			jestExpect(spyAddIssueToProject).toHaveBeenCalledTimes(1)
 		})
 
@@ -571,8 +576,9 @@ describe('Commands', () => {
 					action: 'addToProject',
 					addToProject: {
 						url: testProjectUrl,
+						column: 'To Do',
+						org: testOrgName,
 					},
-					org: testOrgName,
 					name: 'plugins-platform',
 				},
 			]

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -20,7 +20,7 @@ export type Command = { name: string } & (
 		action?: 'close' | 'addToProject'
 	} & Partial<{ comment: string; addLabel: string; removeLabel: string }> &
 	Partial<{ requireLabel: string; disallowLabel: string }>
-	& Partial<{ addToProject: { url: string } }>
+	& Partial<{ addToProject: { url: string, org?: string, column?: string } }>
 /* eslint-enable */
 
 export class Commands {
@@ -180,7 +180,14 @@ export class Commands {
 		) {
 			const projectId = getProjectIdFromUrl(command.addToProject.url)
 			if (projectId) {
-				tasks.push(this.github.addIssueToProject(projectId, issue))
+				tasks.push(
+					this.github.addIssueToProject(
+						projectId,
+						issue,
+						command.addToProject.org,
+						command.addToProject.column,
+					),
+				)
 			} else {
 				console.debug('Could not parse project id from the provided URL', command.addToProject.url)
 			}


### PR DESCRIPTION
Add support for adding issues based on labels to "old" github projects

How to test?
- Add label "plugins" to [this issue](https://github.com/grafana/github-actions-testrepo/issues/31)
- It will add it to both projects because of [this config](https://github.com/grafana/github-actions-testrepo/blob/main/.github/issue-commands.json#L2-L18)