### PR TITLE
fix(77): should add changelog properly into the index file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"description": "GitHub Actions used by VS Code for triaging issues",
 	"scripts": {
-		"test": "jest test --silent",
+		"test": "jest --silent",
 		"build": "tsc",
 		"lint": "eslint -c .eslintrc --fix --ext .ts .",
 		"watch": "tsc --watch"

--- a/update-changelog/testdata/_index.md
+++ b/update-changelog/testdata/_index.md
@@ -8,6 +8,8 @@ weight = 10000
 Here you can find detailed release notes that list everything that is included in every release as well as notices
 about deprecations, breaking changes as well as changes that relate to plugin development.
 
+- [Release notes for 8.4.0-beta1]({{< relref "release-notes-8-4-0-beta1" >}})
+- [Release notes for 8.3.4]({{< relref "release-notes-8-3-3" >}})
 - [Release notes for 8.3.3]({{< relref "release-notes-8-3-3" >}})
 - [Release notes for 8.3.2]({{< relref "release-notes-8-3-2" >}})
 - [Release notes for 8.3.1]({{< relref "release-notes-8-3-1" >}})

--- a/update-changelog/writeDocsFiles.js
+++ b/update-changelog/writeDocsFiles.js
@@ -27,7 +27,7 @@ ${notes}
     const indexFileFullPath = `${releaseNotesDocsPath}/${indexFilePath}`;
     const indexFileContent = fs_1.default.readFileSync(indexFileFullPath, 'utf8');
     // check if reference already exists
-    const findExistingReference = indexFileContent.indexOf(releaseNotesName);
+    const findExistingReference = indexFileContent.indexOf('"' + releaseNotesName + '"');
     // only add reference if it does not exist already
     if (findExistingReference === -1) {
         // find the right place to put release notes into.

--- a/update-changelog/writeDocsFiles.test.ts
+++ b/update-changelog/writeDocsFiles.test.ts
@@ -96,7 +96,7 @@ describe('writeDocsFiles', () => {
 		expect(matches).toBe(1)
 	})
 
-	test.only('should add previous version release notes at the proper position', async () => {
+	test('should add previous version release notes at the proper position', async () => {
 		// Arrange
 		mock({
 			docs: {
@@ -126,7 +126,7 @@ describe('writeDocsFiles', () => {
 		)
 	})
 
-	test.only('should add version 9.0.0-beta1 to the very front', async () => {
+	test('should add version 9.0.0-beta1 to the very front', async () => {
 		// Arrange
 		mock({
 			docs: {
@@ -152,11 +152,11 @@ describe('writeDocsFiles', () => {
 		expect(builder.buildReleaseNotes).toHaveBeenCalledTimes(1)
 		const result = readFileSync(file, 'utf8')
 		expect(result).toContain(
-			'- [Release notes for 9.0.0-beta1]({{< relref "release-notes-9-0-0-beta1" >}})\n- [Release notes for 8.3.3]({{< relref "release-notes-8-3-3" >}})',
+			'- [Release notes for 9.0.0-beta1]({{< relref "release-notes-9-0-0-beta1" >}})\n- [Release notes for 8.4.0-beta1]({{< relref "release-notes-8-4-0-beta1" >}})',
 		)
 	})
 
-	test.only('should add version 7.2.0 to the very end', async () => {
+	test('should add version 7.2.0 to the very end', async () => {
 		// Arrange
 		mock({
 			docs: {
@@ -183,6 +183,35 @@ describe('writeDocsFiles', () => {
 		const result = readFileSync(file, 'utf8')
 		expect(result).toContain(
 			'- [Release notes for 7.3.0]({{< relref "release-notes-7-3-0" >}})\n- [Release notes for 7.2.0]({{< relref "release-notes-7-2-0" >}})',
+		)
+	})
+	test.only('should add version 8.4.0 after 8.4.0-beta1', async () => {
+		// Arrange
+		mock({
+			docs: {
+				sources: {
+					'release-notes': {
+						'release-notes-8-4-0.md': 'Empty file',
+						'_index.md': readFileSync(path.resolve(__dirname, 'testdata/_index.md'), 'utf8'),
+					},
+				},
+			},
+		})
+		const version = '8.4.0'
+		const file = './docs/sources/release-notes/_index.md'
+		const builder = {
+			buildReleaseNotes: jest.fn().mockResolvedValue('Release notes'),
+			getTitle: jest.fn().mockReturnValue('This is my test title'),
+		} as unknown as ReleaseNotesBuilder
+
+		// Act
+		await writeDocsFiles({ version, builder })
+
+		// Assert
+		expect(builder.buildReleaseNotes).toHaveBeenCalledTimes(1)
+		const result = readFileSync(file, 'utf8')
+		expect(result).toContain(
+			'- [Release notes for 8.4.0]({{< relref "release-notes-8-4-0" >}})\n- [Release notes for 8.4.0-beta1]({{< relref "release-notes-8-4-0-beta1" >}})',
 		)
 	})
 })

--- a/update-changelog/writeDocsFiles.ts
+++ b/update-changelog/writeDocsFiles.ts
@@ -33,7 +33,7 @@ ${notes}
 	const indexFileContent = fs.readFileSync(indexFileFullPath, 'utf8')
 
 	// check if reference already exists
-	const findExistingReference = indexFileContent.indexOf(releaseNotesName)
+	const findExistingReference = indexFileContent.indexOf('"' + releaseNotesName + '"')
 
 	// only add reference if it does not exist already
 	if (findExistingReference === -1) {


### PR DESCRIPTION
**Why?**
This PR fixes a bug that sometimes a link to changelog is not added to the index file when update changelog action runs.
Reason for that is we were double checking if a link to the changelog file to be added already exists. The check although was not very strict and matched also when it should not have.

e.g. `8.4.0` matched on `8.4.0-beta1`

This PR makes the check more strict and should prevent errors like that from happening. Also added a unit test to cover this use case.

**Fixes #77**