### PR TITLE
Fix/type missmatch

### DIFF
--- a/api/octokit.js
+++ b/api/octokit.js
@@ -318,7 +318,7 @@ class OctoKit {
     }
     async addIssueToProjectNext(projectNodeId, issueNodeId) {
         console.log('Running addIssueToProjectNext with: projectNodeId: ', projectNodeId, ' issueNodeId: ', issueNodeId);
-        const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
+        const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {
 				id

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -333,7 +333,7 @@ class OctoKit {
     }
     async getItemIdFromIssueProjectNext(projectNodeId, issueNodeId) {
         console.log('Running getItemIdFromIssueProjectNext with: projectNodeId: ', projectNodeId, ' issueNodeId: ', issueNodeId);
-        const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
+        const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {
 				id

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -288,7 +288,7 @@ class OctoKit {
     }
     async addIssueToProjectOld(projectColumnId, issueNodeId) {
         console.log('Running addIssueToProjectOld with: projectColumnId: ', projectColumnId, ' issueNodeId: ', issueNodeId);
-        const mutation = `mutation addProjectCard($projectColumnId: String!, $issueNodeId: String!) {
+        const mutation = `mutation addProjectCard($projectColumnId: ID!, $issueNodeId: ID!) {
 			addProjectCard(input: {projectColumnId: $projectColumnId, contentId: $issueNodeId}) {
 				cardEdge {
 					node {
@@ -305,7 +305,7 @@ class OctoKit {
     }
     async removeIssueFromProjectOld(projectNodeId, issueNodeId) {
         console.log('Running removeIssueFromProjectOld with: projectNodeId: ', projectNodeId, ' issueNodeId: ', issueNodeId);
-        const mutation = `mutation deleteProjectNextItem($projectNodeId: String!, $issueNodeId: String!) {
+        const mutation = `mutation deleteProjectNextItem($projectNodeId: ID!, $issueNodeId: ID!) {
 			deleteProjectNextItem(input: {projectId: $projectNodeId, itemId: $issueNodeId}) {
 				deletedItemId
 			}
@@ -333,7 +333,7 @@ class OctoKit {
     }
     async getItemIdFromIssueProjectNext(projectNodeId, issueNodeId) {
         console.log('Running getItemIdFromIssueProjectNext with: projectNodeId: ', projectNodeId, ' issueNodeId: ', issueNodeId);
-        const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
+        const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {
 				id
@@ -356,7 +356,7 @@ class OctoKit {
     }
     async removeIssueFromProjectNext(projectNodeId, issueNodeId) {
         console.log('Running removeIssueFromProjectNext with: projectNodeId: ', projectNodeId, 'issueNodeId: ', issueNodeId);
-        const mutation = `mutation removeIssueFromProject($projectNodeId: String!, $issueNodeId: String!){
+        const mutation = `mutation removeIssueFromProject($projectNodeId: ID!, $issueNodeId: ID!){
 			deleteProjectNextItem(
 			  input: {
 				projectId: $projectNodeId

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -333,7 +333,7 @@ class OctoKit {
     }
     async getItemIdFromIssueProjectNext(projectNodeId, issueNodeId) {
         console.log('Running getItemIdFromIssueProjectNext with: projectNodeId: ', projectNodeId, ' issueNodeId: ', issueNodeId);
-        const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
+        const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {
 				id

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -404,7 +404,7 @@ export class OctoKit implements GitHub {
 			issueNodeId,
 		)
 
-		const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
+		const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {
 				id

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -379,7 +379,7 @@ export class OctoKit implements GitHub {
 			issueNodeId,
 		)
 
-		const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
+		const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {
 				id

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -404,7 +404,7 @@ export class OctoKit implements GitHub {
 			issueNodeId,
 		)
 
-		const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
+		const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {
 				id

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -336,7 +336,7 @@ export class OctoKit implements GitHub {
 			' issueNodeId: ',
 			issueNodeId,
 		)
-		const mutation = `mutation addProjectCard($projectColumnId: String!, $issueNodeId: String!) {
+		const mutation = `mutation addProjectCard($projectColumnId: ID!, $issueNodeId: ID!) {
 			addProjectCard(input: {projectColumnId: $projectColumnId, contentId: $issueNodeId}) {
 				cardEdge {
 					node {
@@ -359,7 +359,7 @@ export class OctoKit implements GitHub {
 			' issueNodeId: ',
 			issueNodeId,
 		)
-		const mutation = `mutation deleteProjectNextItem($projectNodeId: String!, $issueNodeId: String!) {
+		const mutation = `mutation deleteProjectNextItem($projectNodeId: ID!, $issueNodeId: ID!) {
 			deleteProjectNextItem(input: {projectId: $projectNodeId, itemId: $issueNodeId}) {
 				deletedItemId
 			}
@@ -404,7 +404,7 @@ export class OctoKit implements GitHub {
 			issueNodeId,
 		)
 
-		const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
+		const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
 			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
 			  projectNextItem {
 				id
@@ -436,7 +436,7 @@ export class OctoKit implements GitHub {
 			issueNodeId,
 		)
 
-		const mutation = `mutation removeIssueFromProject($projectNodeId: String!, $issueNodeId: String!){
+		const mutation = `mutation removeIssueFromProject($projectNodeId: ID!, $issueNodeId: ID!){
 			deleteProjectNextItem(
 			  input: {
 				projectId: $projectNodeId


### PR DESCRIPTION
Github has decided to adjust the GraphQL type and does not accept string anymore as input parameter for `addProjectNextItem`, `addProjectCard`,`removeIssueFromProject`, `deleteProjectNextItem`  mutations. This leads to requests being rejected with:

```
GraphqlResponseError: Request failed due to following response errors:
 - Type mismatch on variable $projectNodeId and argument projectId (String! / ID!)
 - Type mismatch on variable $issueNodeId and argument contentId (String! / ID!)
```