### PR TITLE
Refactor: remove unnecessary code

### DIFF
--- a/api/octokit.js
+++ b/api/octokit.js
@@ -331,29 +331,6 @@ class OctoKit {
             issueNodeId,
         });
     }
-    async getItemIdFromIssueProjectNext(projectNodeId, issueNodeId) {
-        console.log('Running getItemIdFromIssueProjectNext with: projectNodeId: ', projectNodeId, ' issueNodeId: ', issueNodeId);
-        const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
-			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
-			  projectNextItem {
-				id
-			  }
-			}
-		}`;
-        try {
-            const results = (await this._octokitGraphQL({
-                query: mutation,
-                projectNodeId,
-                issueNodeId,
-            }));
-            console.debug('getItemIdFromIssueProjectNext results' + JSON.stringify(results));
-            return results.addProjectNextItem.projectNextItem.id;
-        }
-        catch (error) {
-            console.error('getItemIdFromIssueProjectNext failed: ' + error);
-        }
-        return undefined;
-    }
     async removeIssueFromProjectNext(projectNodeId, issueNodeId) {
         console.log('Running removeIssueFromProjectNext with: projectNodeId: ', projectNodeId, 'issueNodeId: ', issueNodeId);
         const mutation = `mutation removeIssueFromProject($projectNodeId: String!, $issueNodeId: String!){
@@ -403,17 +380,12 @@ class OctoKit {
                 return;
             }
             if (project.projectType === api_1.projectType.ProjectNext) {
-                const issueNodeId = await this.getItemIdFromIssueProjectNext(project.projectNodeId, issue.nodeId);
-                if (issueNodeId) {
-                    await this.removeIssueFromProjectNext(project.projectNodeId, issueNodeId);
-                }
-                else {
-                    console.error('Could not find item id for issue: ' + issue.nodeId);
-                    return;
-                }
+                await this.removeIssueFromProjectNext(project.projectNodeId, issue.nodeId);
+                return;
             }
             else if (project.projectType === api_1.projectType.Project) {
                 await this.removeIssueFromProjectOld(project.projectNodeId, issue.nodeId);
+                return;
             }
             else {
                 console.error('Unknown project type: ' + project);

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -343,7 +343,7 @@ class OctoKit {
 					id
 					title
 					project {
-					  url
+					  id
 					}
 				  }
 				}

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -331,29 +331,6 @@ class OctoKit {
             issueNodeId,
         });
     }
-    async getItemIdFromIssueProjectNext(projectNodeId, issueNodeId) {
-        console.log('Running getItemIdFromIssueProjectNext with: projectNodeId: ', projectNodeId, ' issueNodeId: ', issueNodeId);
-        const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
-			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
-			  projectNextItem {
-				id
-			  }
-			}
-		}`;
-        try {
-            const results = (await this._octokitGraphQL({
-                query: mutation,
-                projectNodeId,
-                issueNodeId,
-            }));
-            console.debug('getItemIdFromIssueProjectNext results' + JSON.stringify(results));
-            return results.addProjectNextItem.projectNextItem.id;
-        }
-        catch (error) {
-            console.error('getItemIdFromIssueProjectNext failed: ' + error);
-        }
-        return undefined;
-    }
     async removeIssueFromProjectNext(projectNodeId, issueNodeId) {
         console.log('Running removeIssueFromProjectNext with: projectNodeId: ', projectNodeId, 'issueNodeId: ', issueNodeId);
         const mutation = `mutation removeIssueFromProject($projectNodeId: ID!, $issueNodeId: ID!){

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -393,41 +393,6 @@ export class OctoKit implements GitHub {
 		})
 	}
 
-	protected async getItemIdFromIssueProjectNext(
-		projectNodeId: string,
-		issueNodeId: string,
-	): Promise<string | undefined> {
-		console.log(
-			'Running getItemIdFromIssueProjectNext with: projectNodeId: ',
-			projectNodeId,
-			' issueNodeId: ',
-			issueNodeId,
-		)
-
-		const mutation = `mutation addIssueToProject($projectNodeId: String!, $issueNodeId: String!){
-			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
-			  projectNextItem {
-				id
-			  }
-			}
-		}`
-
-		try {
-			const results = (await this._octokitGraphQL({
-				query: mutation,
-				projectNodeId,
-				issueNodeId,
-			})) as GraphQlQueryResponseData
-
-			console.debug('getItemIdFromIssueProjectNext results' + JSON.stringify(results))
-
-			return results.addProjectNextItem.projectNextItem.id
-		} catch (error) {
-			console.error('getItemIdFromIssueProjectNext failed: ' + error)
-		}
-		return undefined
-	}
-
 	protected async removeIssueFromProjectNext(projectNodeId: string, issueNodeId: string) {
 		console.log(
 			'Running removeIssueFromProjectNext with: projectNodeId: ',
@@ -489,18 +454,11 @@ export class OctoKit implements GitHub {
 				return
 			}
 			if (project.projectType === projectType.ProjectNext) {
-				const issueNodeId = await this.getItemIdFromIssueProjectNext(
-					project.projectNodeId,
-					issue.nodeId,
-				)
-				if (issueNodeId) {
-					await this.removeIssueFromProjectNext(project.projectNodeId, issueNodeId)
-				} else {
-					console.error('Could not find item id for issue: ' + issue.nodeId)
-					return
-				}
+				await this.removeIssueFromProjectNext(project.projectNodeId, issue.nodeId)
+				return
 			} else if (project.projectType === projectType.Project) {
 				await this.removeIssueFromProjectOld(project.projectNodeId, issue.nodeId)
+				return
 			} else {
 				console.error('Unknown project type: ' + project)
 			}

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -393,41 +393,6 @@ export class OctoKit implements GitHub {
 		})
 	}
 
-	protected async getItemIdFromIssueProjectNext(
-		projectNodeId: string,
-		issueNodeId: string,
-	): Promise<string | undefined> {
-		console.log(
-			'Running getItemIdFromIssueProjectNext with: projectNodeId: ',
-			projectNodeId,
-			' issueNodeId: ',
-			issueNodeId,
-		)
-
-		const mutation = `mutation addIssueToProject($projectNodeId: ID!, $issueNodeId: ID!){
-			addProjectNextItem(input: {projectId: $projectNodeId, contentId: $issueNodeId}) {
-			  projectNextItem {
-				id
-			  }
-			}
-		}`
-
-		try {
-			const results = (await this._octokitGraphQL({
-				query: mutation,
-				projectNodeId,
-				issueNodeId,
-			})) as GraphQlQueryResponseData
-
-			console.debug('getItemIdFromIssueProjectNext results' + JSON.stringify(results))
-
-			return results.addProjectNextItem.projectNextItem.id
-		} catch (error) {
-			console.error('getItemIdFromIssueProjectNext failed: ' + error)
-		}
-		return undefined
-	}
-
 	protected async removeIssueFromProjectNext(projectNodeId: string, issueNodeId: string) {
 		console.log(
 			'Running removeIssueFromProjectNext with: projectNodeId: ',

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -414,7 +414,7 @@ export class OctoKit implements GitHub {
 					id
 					title
 					project {
-					  url
+					  id
 					}
 				  }
 				}


### PR DESCRIPTION
**Why?**
`nodeId` value already exists in the Issue object that we are casting from the github event. This makes it unnecessary to fetch it again so I've removed `getItemIdFromIssueProjectNext` function and it's references.