### PR TITLE
New action:  Documentation Target

### DIFF
--- a/docs-target/action.yaml
+++ b/docs-target/action.yaml
@@ -1,0 +1,12 @@
+name: DocsTarget
+description: Extract the version from the given branch
+inputs:
+  ref_name:
+    description: Branch or tag name to extract from
+    default: ${{ github.ref_name }}
+outputs:
+  target:
+    description: The folder name for the given 
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/docs-target/index.js
+++ b/docs-target/index.js
@@ -2,37 +2,32 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const core_1 = require("@actions/core");
 const utils_1 = require("../common/utils");
-const core_2 = require("@actions/core");
+const semver_1 = require("semver");
 let forcePrefix = 'v';
 let trimPrefixes = ['release-', 'v'];
 let knownRefs = new Map([['main', 'next']]);
 function setTarget(target) {
     console.log('Output target: ' + target);
-    (0, core_2.setOutput)('target', target);
+    (0, core_1.setOutput)('target', target);
 }
 function run() {
     try {
-        var ref_name = (0, utils_1.getRequiredInput)('ref_name');
-        console.log('Input ref_name: ' + ref_name);
-        var target = knownRefs.get(ref_name);
-        if (target != undefined) {
-            setTarget(target);
+        var ref = (0, utils_1.getRequiredInput)('ref_name');
+        console.log('Input ref_name: ' + ref);
+        if (knownRefs.has(ref)) {
+            setTarget(knownRefs.get(ref));
             return;
         }
         trimPrefixes.forEach((prefix) => {
-            if (ref_name.startsWith(prefix)) {
-                ref_name = ref_name.slice(prefix.length);
+            if (ref.startsWith(prefix)) {
+                ref = ref.slice(prefix.length);
             }
         });
-        // The node semver package can't parse things like "x.y" without patch
-        // https://github.com/npm/node-semver/issues/164#issuecomment-247157991
-        // So doing cheap way to get major.minor
-        let parts = ref_name.split('.', 2);
-        if (parts.length != 2) {
-            throw 'ref_name invalid: ' + ref_name;
+        var ver = (0, semver_1.coerce)(ref);
+        if (ver == null) {
+            throw 'ref_name invalid: ' + ref;
         }
-        target = forcePrefix + parts[0] + '.' + parts[1];
-        setTarget(target);
+        setTarget(forcePrefix + ver.major + '.' + ver.minor);
     }
     catch (error) {
         (0, core_1.setFailed)(error);

--- a/docs-target/index.js
+++ b/docs-target/index.js
@@ -2,36 +2,15 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const core_1 = require("@actions/core");
 const utils_1 = require("../common/utils");
-const semver_1 = require("semver");
-let forcePrefix = 'v';
-let trimPrefixes = ['release-', 'v'];
-let knownRefs = new Map([['main', 'next']]);
-function setTarget(target) {
+const map_1 = require("./map");
+try {
+    var ref = (0, utils_1.getRequiredInput)('ref_name');
+    console.log('Input ref_name: ' + ref);
+    let target = (0, map_1.map)(ref);
     console.log('Output target: ' + target);
     (0, core_1.setOutput)('target', target);
 }
-function run() {
-    try {
-        var ref = (0, utils_1.getRequiredInput)('ref_name');
-        console.log('Input ref_name: ' + ref);
-        if (knownRefs.has(ref)) {
-            setTarget(knownRefs.get(ref));
-            return;
-        }
-        trimPrefixes.forEach((prefix) => {
-            if (ref.startsWith(prefix)) {
-                ref = ref.slice(prefix.length);
-            }
-        });
-        var ver = (0, semver_1.coerce)(ref);
-        if (ver == null) {
-            throw 'ref_name invalid: ' + ref;
-        }
-        setTarget(forcePrefix + ver.major + '.' + ver.minor);
-    }
-    catch (error) {
-        (0, core_1.setFailed)(error);
-    }
+catch (error) {
+    (0, core_1.setFailed)(error);
 }
-run();
 //# sourceMappingURL=index.js.map

--- a/docs-target/index.js
+++ b/docs-target/index.js
@@ -1,0 +1,42 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const core_1 = require("@actions/core");
+const utils_1 = require("../common/utils");
+const core_2 = require("@actions/core");
+let forcePrefix = 'v';
+let trimPrefixes = ['release-', 'v'];
+let knownRefs = new Map([['main', 'next']]);
+function setTarget(target) {
+    console.log('Output target: ' + target);
+    (0, core_2.setOutput)('target', target);
+}
+function run() {
+    try {
+        var ref_name = (0, utils_1.getRequiredInput)('ref_name');
+        console.log('Input ref_name: ' + ref_name);
+        var target = knownRefs.get(ref_name);
+        if (target != undefined) {
+            setTarget(target);
+            return;
+        }
+        trimPrefixes.forEach((prefix) => {
+            if (ref_name.startsWith(prefix)) {
+                ref_name = ref_name.slice(prefix.length);
+            }
+        });
+        // The node semver package can't parse things like "x.y" without patch
+        // https://github.com/npm/node-semver/issues/164#issuecomment-247157991
+        // So doing cheap way to get major.minor
+        let parts = ref_name.split('.', 2);
+        if (parts.length != 2) {
+            throw 'ref_name invalid: ' + ref_name;
+        }
+        target = forcePrefix + parts[0] + '.' + parts[1];
+        setTarget(target);
+    }
+    catch (error) {
+        (0, core_1.setFailed)(error);
+    }
+}
+run();
+//# sourceMappingURL=index.js.map

--- a/docs-target/index.ts
+++ b/docs-target/index.ts
@@ -1,26 +1,20 @@
 import { setFailed } from '@actions/core'
 import { getRequiredInput } from '../common/utils'
-import { setOutput} from '@actions/core'
+import { setOutput } from '@actions/core'
 
-let forcePrefix = "v"
-let trimPrefixes : string[] = [
-	"release-",
-	"v",
-]
+let forcePrefix = 'v'
+let trimPrefixes: string[] = ['release-', 'v']
+let knownRefs = new Map<string, string>([['main', 'next']])
 
-let knownRefs = new Map<string,string> ([
-	["main", "next"],
-])
-
-function setTarget(target : string) {
-	console.log("Output target: " + target)
-	setOutput("target", target)
+function setTarget(target: string) {
+	console.log('Output target: ' + target)
+	setOutput('target', target)
 }
 
 function run() {
 	try {
-		var ref_name : string = getRequiredInput("ref_name")
-		console.log("Input ref_name: " + ref_name)
+		var ref_name: string = getRequiredInput('ref_name')
+		console.log('Input ref_name: ' + ref_name)
 
 		var target = knownRefs.get(ref_name)
 		if (target != undefined) {
@@ -28,24 +22,24 @@ function run() {
 			return
 		}
 
-		trimPrefixes.forEach(prefix => {
+		trimPrefixes.forEach((prefix) => {
 			if (ref_name.startsWith(prefix)) {
 				ref_name = ref_name.slice(prefix.length)
 			}
-		});
+		})
 
 		// The node semver package can't parse things like "x.y" without patch
 		// https://github.com/npm/node-semver/issues/164#issuecomment-247157991
 		// So doing cheap way to get major.minor
-		let parts = ref_name.split(".", 2)
+		let parts = ref_name.split('.', 2)
 		if (parts.length != 2) {
-			throw "ref_name invalid: " + ref_name
+			throw 'ref_name invalid: ' + ref_name
 		}
 
-		target = forcePrefix + parts[0] + "." + parts[1]
+		target = forcePrefix + parts[0] + '.' + parts[1]
 		setTarget(target)
-	} catch (error : any) {
-		setFailed(error);
+	} catch (error: any) {
+		setFailed(error)
 	}
 }
 

--- a/docs-target/index.ts
+++ b/docs-target/index.ts
@@ -1,40 +1,15 @@
 import { setOutput, setFailed } from '@actions/core'
 import { getRequiredInput } from '../common/utils'
-import { coerce } from 'semver'
+import { map } from './map'
 
-let forcePrefix = 'v'
-let trimPrefixes: string[] = ['release-', 'v']
-let knownRefs = new Map<string, string>([['main', 'next']])
+try {
+	var ref = getRequiredInput('ref_name')
+	console.log('Input ref_name: ' + ref)
 
-function setTarget(target: string) {
+	let target = map(ref)
+
 	console.log('Output target: ' + target)
 	setOutput('target', target)
+} catch (error: any) {
+	setFailed(error)
 }
-
-function run() {
-	try {
-		var ref = getRequiredInput('ref_name')
-		console.log('Input ref_name: ' + ref)
-
-		if (knownRefs.has(ref)) {
-			setTarget(knownRefs.get(ref)!)
-			return
-		}
-
-		trimPrefixes.forEach((prefix) => {
-			if (ref.startsWith(prefix)) {
-				ref = ref.slice(prefix.length)
-			}
-		})
-
-		var ver = coerce(ref)
-		if (ver == null) {
-			throw 'ref_name invalid: ' + ref
-		}
-		setTarget(forcePrefix + ver.major + '.' + ver.minor)
-	} catch (error: any) {
-		setFailed(error)
-	}
-}
-
-run()

--- a/docs-target/index.ts
+++ b/docs-target/index.ts
@@ -1,0 +1,52 @@
+import { setFailed } from '@actions/core'
+import { getRequiredInput } from '../common/utils'
+import { setOutput} from '@actions/core'
+
+let forcePrefix = "v"
+let trimPrefixes : string[] = [
+	"release-",
+	"v",
+]
+
+let knownRefs = new Map<string,string> ([
+	["main", "next"],
+])
+
+function setTarget(target : string) {
+	console.log("Output target: " + target)
+	setOutput("target", target)
+}
+
+function run() {
+	try {
+		var ref_name : string = getRequiredInput("ref_name")
+		console.log("Input ref_name: " + ref_name)
+
+		var target = knownRefs.get(ref_name)
+		if (target != undefined) {
+			setTarget(target)
+			return
+		}
+
+		trimPrefixes.forEach(prefix => {
+			if (ref_name.startsWith(prefix)) {
+				ref_name = ref_name.slice(prefix.length)
+			}
+		});
+
+		// The node semver package can't parse things like "x.y" without patch
+		// https://github.com/npm/node-semver/issues/164#issuecomment-247157991
+		// So doing cheap way to get major.minor
+		let parts = ref_name.split(".", 2)
+		if (parts.length != 2) {
+			throw "ref_name invalid: " + ref_name
+		}
+
+		target = forcePrefix + parts[0] + "." + parts[1]
+		setTarget(target)
+	} catch (error : any) {
+		setFailed(error);
+	}
+}
+
+run()

--- a/docs-target/map.js
+++ b/docs-target/map.js
@@ -1,0 +1,27 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.map = void 0;
+const semver_1 = require("semver");
+let forcePrefix = 'v';
+let trimPrefixes = ['release-', 'v'];
+let knownRefs = new Map([['main', 'next']]);
+// map the given git reference (branch or tag name) to the corresponding
+// documentation subfolder. The output will be "vMajor.Minor"
+function map(ref) {
+    // Hard-coded mapping?
+    if (knownRefs.has(ref)) {
+        return knownRefs.get(ref);
+    }
+    trimPrefixes.forEach((prefix) => {
+        if (ref.startsWith(prefix)) {
+            ref = ref.slice(prefix.length);
+        }
+    });
+    var ver = (0, semver_1.coerce)(ref);
+    if (ver == null) {
+        throw 'ref_name invalid: ' + ref;
+    }
+    return forcePrefix + ver.major + '.' + ver.minor;
+}
+exports.map = map;
+//# sourceMappingURL=map.js.map

--- a/docs-target/map.test.ts
+++ b/docs-target/map.test.ts
@@ -1,0 +1,9 @@
+import { map } from './map'
+
+test('mappings', () => {
+	expect(map('v1.2.3')).toBe('v1.2')
+	expect(map('release-1.3')).toBe('v1.3')
+	expect(map('main')).toBe('next')
+
+	expect(() => map('foo')).toThrow()
+})

--- a/docs-target/map.ts
+++ b/docs-target/map.ts
@@ -1,0 +1,27 @@
+import { coerce } from 'semver'
+
+let forcePrefix = 'v'
+let trimPrefixes: string[] = ['release-', 'v']
+let knownRefs = new Map<string, string>([['main', 'next']])
+
+// map the given git reference (branch or tag name) to the corresponding
+// documentation subfolder. The output will be "vMajor.Minor"
+export function map(ref: string): string {
+	// Hard-coded mapping?
+	if (knownRefs.has(ref)) {
+		return knownRefs.get(ref)!
+	}
+
+	trimPrefixes.forEach((prefix) => {
+		if (ref.startsWith(prefix)) {
+			ref = ref.slice(prefix.length)
+		}
+	})
+
+	var ver = coerce(ref)
+	if (ver == null) {
+		throw 'ref_name invalid: ' + ref
+	}
+
+	return forcePrefix + ver.major + '.' + ver.minor
+}


### PR DESCRIPTION
This PR creates a new action `DocsTarget` that will help achieve improved automation for synchronizing website documentation from upstream repositories such as [Tempo](https://github.com/grafana/tempo), to the [website](https://github.com/grafana/website) repo.  When a docs update is committed, or a new release tagged, then this action helps to determine the destination subfolder.   In summary, it will convert a branch or tag name like `release-1.2.3` into the subfolder name `v1.2`.

This action is expected to be useful to multiple projects, so adding to this shared repo makes sense.  Please see this [grafana/agent PR](https://github.com/grafana/agent/pull/1515) for related testing and discussion, and there is further internal discussion that we can link to if needed.
