### PR TITLE
Make trim prefixes configurable

### DIFF
--- a/common/globmatcher.js
+++ b/common/globmatcher.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];

--- a/common/utils.js
+++ b/common/utils.js
@@ -5,7 +5,11 @@
  *--------------------------------------------------------------------------------------------*/
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];

--- a/docs-target/action.yaml
+++ b/docs-target/action.yaml
@@ -4,9 +4,12 @@ inputs:
   ref_name:
     description: Branch or tag name to extract from
     default: ${{ github.ref_name }}
+  trim_prefixes:
+    description: Colon `:` separated list of prefixes to be trimmed from references
+    default: 'release-:v'
 outputs:
   target:
-    description: The folder name for the given 
+    description: Website documentation version for the given reference
 runs:
   using: 'node16'
   main: 'index.js'

--- a/docs-target/index.js
+++ b/docs-target/index.js
@@ -5,8 +5,9 @@ const utils_1 = require("../common/utils");
 const map_1 = require("./map");
 try {
     var ref = (0, utils_1.getRequiredInput)('ref_name');
+    var trimPrefixes = (0, utils_1.getRequiredInput)('trim_prefixes').split(':');
     console.log('Input ref_name: ' + ref);
-    let target = (0, map_1.map)(ref);
+    let target = (0, map_1.map)(ref, trimPrefixes);
     console.log('Output target: ' + target);
     (0, core_1.setOutput)('target', target);
 }

--- a/docs-target/index.ts
+++ b/docs-target/index.ts
@@ -4,9 +4,10 @@ import { map } from './map'
 
 try {
 	var ref = getRequiredInput('ref_name')
+	var trimPrefixes = getRequiredInput('trim_prefixes').split(':')
 	console.log('Input ref_name: ' + ref)
 
-	let target = map(ref)
+	let target = map(ref, trimPrefixes)
 
 	console.log('Output target: ' + target)
 	setOutput('target', target)

--- a/docs-target/map.js
+++ b/docs-target/map.js
@@ -3,11 +3,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.map = void 0;
 const semver_1 = require("semver");
 let forcePrefix = 'v';
-let trimPrefixes = ['release-', 'v'];
 let knownRefs = new Map([['main', 'next']]);
 // map the given git reference (branch or tag name) to the corresponding
-// documentation subfolder. The output will be "vMajor.Minor"
-function map(ref) {
+// documentation subfolder, trimming any provided prefixes.
+// The output will be "vMajor.Minor"
+function map(ref, trimPrefixes) {
     // Hard-coded mapping?
     if (knownRefs.has(ref)) {
         return knownRefs.get(ref);

--- a/docs-target/map.test.ts
+++ b/docs-target/map.test.ts
@@ -1,9 +1,11 @@
 import { map } from './map'
 
 test('mappings', () => {
-	expect(map('v1.2.3')).toBe('v1.2')
-	expect(map('release-1.3')).toBe('v1.3')
-	expect(map('main')).toBe('next')
+	expect(map('v1.2.3', ['release-', 'v'])).toBe('v1.2')
+	expect(map('release-1.3', ['release-', 'v'])).toBe('v1.3')
+	expect(map('release-1.4.0', ['release-', 'v'])).toBe('v1.4')
+	expect(map('main', ['release-', 'v'])).toBe('next')
+	expect(map('mimir-2.0.1', ['release-', 'mimir-'])).toBe('v2.0')
 
 	expect(() => map('foo')).toThrow()
 })

--- a/docs-target/map.test.ts
+++ b/docs-target/map.test.ts
@@ -5,6 +5,8 @@ test('mappings', () => {
 	expect(map('release-1.3', ['release-', 'v'])).toBe('v1.3')
 	expect(map('release-1.4.0', ['release-', 'v'])).toBe('v1.4')
 	expect(map('main', ['release-', 'v'])).toBe('next')
+	// Should fail but doesn't
+	expect(map('mimir-2.0.1', ['release-', 'v'])).toBe('v2.0')
 	expect(map('mimir-2.0.1', ['release-', 'mimir-'])).toBe('v2.0')
 
 	expect(() => map('foo')).toThrow()

--- a/docs-target/map.ts
+++ b/docs-target/map.ts
@@ -1,12 +1,12 @@
 import { coerce } from 'semver'
 
 let forcePrefix = 'v'
-let trimPrefixes: string[] = ['release-', 'v']
 let knownRefs = new Map<string, string>([['main', 'next']])
 
 // map the given git reference (branch or tag name) to the corresponding
-// documentation subfolder. The output will be "vMajor.Minor"
-export function map(ref: string): string {
+// documentation subfolder, trimming any provided prefixes.
+// The output will be "vMajor.Minor"
+export function map(ref: string, trimPrefixes: Array<string>): string {
 	// Hard-coded mapping?
 	if (knownRefs.has(ref)) {
 		return knownRefs.get(ref)!


### PR DESCRIPTION
Please take extra care in this review because I'm not very familiar with JavaScript/TypeScript or GitHub workflows.

I would like to make the trim prefixes configurable so that the Mimir repository can use this workflow. The Mimir repo uses `mimir-` as a prefix for tagged releases instead of `v`.

I believe only string inputs are allowed and went with a simple colon-separated convention as I believe colons are not allowed in git tags. Originally, I used commas but commas are acceptable in git tags.

I updated the test cases but I have trouble making a failing test. Please see the note in the `map.test.ts` file.