### PR TITLE
Add has-matching-release-tag

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -130,7 +130,7 @@ ${JSON.stringify(github_1.context, null, 2)
 };
 exports.logErrorToIssue = logErrorToIssue;
 function splitStringIntoLines(content) {
-    return content.split(/\r?\n/);
+    return content.split(/(?:\r\n|\r|\n)/g);
 }
 exports.splitStringIntoLines = splitStringIntoLines;
 const getProjectIdFromUrl = (url) => {

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -121,7 +121,7 @@ ${JSON.stringify(context, null, 2)
 }
 
 export function splitStringIntoLines(content: string) {
-	return content.split(/\r?\n/)
+	return content.split(/(?:\r\n|\r|\n)/g)
 }
 
 export const getProjectIdFromUrl = (url: string) => {

--- a/has-matching-release-tag/action.yaml
+++ b/has-matching-release-tag/action.yaml
@@ -22,15 +22,21 @@ inputs:
     release_tag_regexp:
         description: |
             Regexp to match release tag references.
+            Must be an escaped string suitable for passing to new RegExp (https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/regexp).
             The regexp must have three capture groups, one for each of major, minor, and patch versions.
+            For example: "^v(\\d+)\\.(\\d+)\\.(\\d+)$"
     release_branch_regexp:
         description: |
             Regexp to match release branches that do not include a patch version.
+            Must be an escaped string suitable for passing to new RegExp (https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/regexp).
             The regexp must have two capture groups, one for each of major and minor versions.
+            For example: "^release-(\\d+)\\.(\\d+)$"
     release_branch_with_patch_regexp:
         description: |
             Regexp to match release branches that include a patch version.
+            Must be an escaped string suitable for passing to new RegExp (https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/regexp).
             The regexp must have three capture groups, one for each of major, minor, and patch versions.
+            For example: "^release-(\\d+)\\.(\\d+)\\.(\\d+)$"
             Can be omitted if not required.
 outputs:
     bool:

--- a/has-matching-release-tag/action.yaml
+++ b/has-matching-release-tag/action.yaml
@@ -1,0 +1,36 @@
+name: 'Has matching release tag'
+description: |
+    Produce a boolean output that has the value "true" if and only if there is a release tag that
+    matches the release branch.
+    If the provided `ref_name` is a release tag reference, the output value is "true".
+    If the provided `ref_name` is a release branch reference, the output value is "true" if
+    and only if there is a matching release tag as defined by the `release_tag_regexp`.
+    For release branches with a patch version, the capture groups for major, minor, and patch
+    versions must match between the `release_branch_with_patch_regexp` and the
+    `release_tag_regexp`.
+    For release branches without a patch version, the capture groups for major and minor
+    versions must match between the `release_branch_without_patch_regexp` and the
+    `release_tag_regexp` and the release tag must have a `0` patch version.
+
+inputs:
+    ref_name:
+        description: 'Branch or tag name'
+        default: '${{ github.ref_name }}'
+    release_tag_regexp:
+        description: |
+            Regexp to match release tag references.
+            The regexp must have three capture groups, one for each of major, minor, and patch versions.
+    release_branch_with_patch_regexp:
+        description: |
+            Regexp to match release branches that include a patch version.
+            The regexp must have three capture groups, one for each of major, minor, and patch versions.
+    release_branch_without_patch_regexp:
+        description: |
+            Regexp to match release branches that do not include a patch version.
+            The regexp must have two capture groups, one for each of major and minor versions.
+outputs:
+    bool:
+        description: 'Boolean represented by either the string value "true" or "false".'
+runs:
+    using: 'node16'
+    main: 'index.js'

--- a/has-matching-release-tag/action.yaml
+++ b/has-matching-release-tag/action.yaml
@@ -2,15 +2,18 @@ name: 'Has matching release tag'
 description: |
     Produce a boolean output that has the value "true" if and only if there is a release tag that
     matches the release branch.
+
     If the provided `ref_name` is a release tag reference, the output value is "true".
     If the provided `ref_name` is a release branch reference, the output value is "true" if
-    and only if there is a matching release tag as defined by the `release_tag_regexp`.
-    For release branches with a patch version, the capture groups for major, minor, and patch
-    versions must match between the `release_branch_with_patch_regexp` and the
-    `release_tag_regexp`.
+    and only if there is a corresponding release tag as defined by the `release_tag_regexp`.
+
     For release branches without a patch version, the capture groups for major and minor
     versions must match between the `release_branch_without_patch_regexp` and the
     `release_tag_regexp` and the release tag must have a `0` patch version.
+
+    For release branches with a patch version, the capture groups for major, minor, and patch
+    versions must match between the `release_branch_with_patch_regexp` and the
+    `release_tag_regexp`.
 
 inputs:
     ref_name:
@@ -20,14 +23,15 @@ inputs:
         description: |
             Regexp to match release tag references.
             The regexp must have three capture groups, one for each of major, minor, and patch versions.
+    release_branch_regexp:
+        description: |
+            Regexp to match release branches that do not include a patch version.
+            The regexp must have two capture groups, one for each of major and minor versions.
     release_branch_with_patch_regexp:
         description: |
             Regexp to match release branches that include a patch version.
             The regexp must have three capture groups, one for each of major, minor, and patch versions.
-    release_branch_without_patch_regexp:
-        description: |
-            Regexp to match release branches that do not include a patch version.
-            The regexp must have two capture groups, one for each of major and minor versions.
+            Can be omitted if not required.
 outputs:
     bool:
         description: 'Boolean represented by either the string value "true" or "false".'

--- a/has-matching-release-tag/hasMatchingReleaseTag.js
+++ b/has-matching-release-tag/hasMatchingReleaseTag.js
@@ -4,7 +4,7 @@ exports.hasMatchingReleaseTagWithRefNames = exports.filterRefNames = exports.has
 const child_process_1 = require("child_process");
 const utils_1 = require("../common/utils");
 function hasMatchingReleaseTag(refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp) {
-    let refNames = (0, utils_1.splitStringIntoLines)((0, child_process_1.execFileSync)('git', ['tag'], { encoding: 'utf8' }));
+    let refNames = (0, utils_1.splitStringIntoLines)((0, child_process_1.execFileSync)('git', ['tag'], { encoding: 'utf8' })).filter((e) => e);
     if (refNames.length == 0) {
         throw 'No tags found. Is there an `actions/checkout` step with `fetch-depth: 0` before this action? https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches';
     }

--- a/has-matching-release-tag/hasMatchingReleaseTag.js
+++ b/has-matching-release-tag/hasMatchingReleaseTag.js
@@ -60,7 +60,7 @@ function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, 
             }
         }
     }
-    console.log(`Found corresponding release tag for reference '${refName}'`);
+    console.log(`Did not find a corresponding release tag for reference '${refName}'`);
     return 'false';
 }
 exports.hasMatchingReleaseTagWithRefNames = hasMatchingReleaseTagWithRefNames;

--- a/has-matching-release-tag/hasMatchingReleaseTag.js
+++ b/has-matching-release-tag/hasMatchingReleaseTag.js
@@ -3,7 +3,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.hasMatchingReleaseTagWithRefNames = exports.filterRefNames = exports.hasMatchingReleaseTag = void 0;
 const child_process_1 = require("child_process");
 function hasMatchingReleaseTag(refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp) {
-    return hasMatchingReleaseTagWithRefNames((0, child_process_1.execFileSync)('git', ['tag'], { encoding: 'utf8' }).split(/(?:\r\n|\r|\n)/g), refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp);
+    let refNames = (0, child_process_1.execFileSync)('git', ['tag'], { encoding: 'utf8' }).split(/(?:\r\n|\r|\n)/g);
+    if (refNames.length == 0) {
+        throw 'No tags found. Is there an `actions/checkout` step with `fetch-depth: 0` before this action? https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches';
+    }
+    return hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp);
 }
 exports.hasMatchingReleaseTag = hasMatchingReleaseTag;
 function filterRefNames(refNames, regexp) {

--- a/has-matching-release-tag/hasMatchingReleaseTag.js
+++ b/has-matching-release-tag/hasMatchingReleaseTag.js
@@ -2,8 +2,9 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.hasMatchingReleaseTagWithRefNames = exports.filterRefNames = exports.hasMatchingReleaseTag = void 0;
 const child_process_1 = require("child_process");
+const utils_1 = require("../common/utils");
 function hasMatchingReleaseTag(refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp) {
-    let refNames = (0, child_process_1.execFileSync)('git', ['tag'], { encoding: 'utf8' }).split(/(?:\r\n|\r|\n)/g);
+    let refNames = (0, utils_1.splitStringIntoLines)((0, child_process_1.execFileSync)('git', ['tag'], { encoding: 'utf8' }));
     if (refNames.length == 0) {
         throw 'No tags found. Is there an `actions/checkout` step with `fetch-depth: 0` before this action? https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches';
     }

--- a/has-matching-release-tag/hasMatchingReleaseTag.js
+++ b/has-matching-release-tag/hasMatchingReleaseTag.js
@@ -28,6 +28,7 @@ exports.filterRefNames = filterRefNames;
 // Otherwise, the function returns "false".
 function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp) {
     if (refName.match(releaseTagRegexp)) {
+        console.log(`Reference name is a release tag`);
         return 'true';
     }
     let releaseTags = filterRefNames(refNames, releaseTagRegexp);
@@ -39,6 +40,7 @@ function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, 
                 tagMatches[1] == branchMatches[1] &&
                 tagMatches[2] == branchMatches[2] &&
                 tagMatches[3] == '0') {
+                console.log(`Found corresponding release tag for branch '${refName}': '${releaseTags[i]}'`);
                 return 'true';
             }
         }
@@ -52,11 +54,13 @@ function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, 
                     tagMatches[1] == branchMatches[1] &&
                     tagMatches[2] == branchMatches[2] &&
                     tagMatches[3] == branchMatches[3]) {
+                    console.log(`Found corresponding release tag for branch '${refName}': '${releaseTags[i]}'`);
                     return 'true';
                 }
             }
         }
     }
+    console.log(`Found corresponding release tag for reference '${refName}'`);
     return 'false';
 }
 exports.hasMatchingReleaseTagWithRefNames = hasMatchingReleaseTagWithRefNames;

--- a/has-matching-release-tag/hasMatchingReleaseTag.js
+++ b/has-matching-release-tag/hasMatchingReleaseTag.js
@@ -1,42 +1,32 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.hasMatchingReleaseTagWithRefNames = exports.filterRefNames = exports.hasMatchingReleaseTag = void 0;
-const exec_1 = require("@actions/exec");
-async function hasMatchingReleaseTag(refName, releaseTagRegexp, releaseBranchWithoutPatchRegexp, releaseBranchWithPatchRegexp) {
-    let refNames = [];
-    const options = {
-        listeners: {
-            stdout: (data) => {
-                refNames = data.toString().split(/(?:\r\n|\r|\n)/g);
-            },
-        },
-    };
-    await (0, exec_1.exec)('git', ['tag'], options);
-    return hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, releaseBranchWithoutPatchRegexp, releaseBranchWithPatchRegexp);
+const child_process_1 = require("child_process");
+function hasMatchingReleaseTag(refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp) {
+    return hasMatchingReleaseTagWithRefNames((0, child_process_1.execFileSync)('git', ['tag'], { encoding: 'utf8' }).split(/(?:\r\n|\r|\n)/g), refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp);
 }
 exports.hasMatchingReleaseTag = hasMatchingReleaseTag;
 function filterRefNames(refNames, regexp) {
     return refNames.filter((name) => name.match(regexp));
 }
 exports.filterRefNames = filterRefNames;
-function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, releaseBranchWithoutPatchRegexp, releaseBranchWithPatchRegexp) {
+// hasMatchingReleaseTagWithRefNames returns either the string "true" or "false".
+// "true" is returned for each of the following cases:
+// - releaseTagRegexp matches refName and is therefore a release tag reference name.
+// - releaseBranchRegexp matches refName and there is a corresponding reference name in
+//   refNames that matched by releaseTagRegexp. For a reference name to be corresponding,
+//   it must share the major and minor versions with refName, and it must have a '0'
+//   patch version.
+// - releaseBranchWithPatchRegexp is defined, matches refName, and there is a corresponding
+//   reference name in matched by releaseTagRegexp. For a reference name to be corresponding,
+//   it must share the major, minor, and patch versions with the refName.
+// Otherwise, the function returns "false".
+function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, releaseBranchRegexp, releaseBranchWithPatchRegexp) {
     if (refName.match(releaseTagRegexp)) {
         return 'true';
     }
     let releaseTags = filterRefNames(refNames, releaseTagRegexp);
-    let branchMatches = refName.match(releaseBranchWithPatchRegexp);
-    if (branchMatches) {
-        for (var i = 0; i < releaseTags.length; i++) {
-            let tagMatches = releaseTags[i].match(releaseTagRegexp);
-            if (tagMatches &&
-                tagMatches[1] == branchMatches[1] &&
-                tagMatches[2] == branchMatches[2] &&
-                tagMatches[3] == branchMatches[3]) {
-                return 'true';
-            }
-        }
-    }
-    branchMatches = refName.match(releaseBranchWithoutPatchRegexp);
+    let branchMatches = refName.match(releaseBranchRegexp);
     if (branchMatches) {
         for (var i = 0; i < releaseTags.length; i++) {
             let tagMatches = releaseTags[i].match(releaseTagRegexp);
@@ -45,6 +35,20 @@ function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, 
                 tagMatches[2] == branchMatches[2] &&
                 tagMatches[3] == '0') {
                 return 'true';
+            }
+        }
+    }
+    if (releaseBranchWithPatchRegexp) {
+        branchMatches = refName.match(releaseBranchWithPatchRegexp);
+        if (branchMatches) {
+            for (var i = 0; i < releaseTags.length; i++) {
+                let tagMatches = releaseTags[i].match(releaseTagRegexp);
+                if (tagMatches &&
+                    tagMatches[1] == branchMatches[1] &&
+                    tagMatches[2] == branchMatches[2] &&
+                    tagMatches[3] == branchMatches[3]) {
+                    return 'true';
+                }
             }
         }
     }

--- a/has-matching-release-tag/hasMatchingReleaseTag.js
+++ b/has-matching-release-tag/hasMatchingReleaseTag.js
@@ -1,0 +1,54 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.hasMatchingReleaseTagWithRefNames = exports.filterRefNames = exports.hasMatchingReleaseTag = void 0;
+const exec_1 = require("@actions/exec");
+async function hasMatchingReleaseTag(refName, releaseTagRegexp, releaseBranchWithoutPatchRegexp, releaseBranchWithPatchRegexp) {
+    let refNames = [];
+    const options = {
+        listeners: {
+            stdout: (data) => {
+                refNames = data.toString().split(/(?:\r\n|\r|\n)/g);
+            },
+        },
+    };
+    await (0, exec_1.exec)('git', ['tag'], options);
+    return hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, releaseBranchWithoutPatchRegexp, releaseBranchWithPatchRegexp);
+}
+exports.hasMatchingReleaseTag = hasMatchingReleaseTag;
+function filterRefNames(refNames, regexp) {
+    return refNames.filter((name) => name.match(regexp));
+}
+exports.filterRefNames = filterRefNames;
+function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, releaseBranchWithoutPatchRegexp, releaseBranchWithPatchRegexp) {
+    if (refName.match(releaseTagRegexp)) {
+        return 'true';
+    }
+    let releaseTags = filterRefNames(refNames, releaseTagRegexp);
+    let branchMatches = refName.match(releaseBranchWithPatchRegexp);
+    if (branchMatches) {
+        for (var i = 0; i < releaseTags.length; i++) {
+            let tagMatches = releaseTags[i].match(releaseTagRegexp);
+            if (tagMatches &&
+                tagMatches[1] == branchMatches[1] &&
+                tagMatches[2] == branchMatches[2] &&
+                tagMatches[3] == branchMatches[3]) {
+                return 'true';
+            }
+        }
+    }
+    branchMatches = refName.match(releaseBranchWithoutPatchRegexp);
+    if (branchMatches) {
+        for (var i = 0; i < releaseTags.length; i++) {
+            let tagMatches = releaseTags[i].match(releaseTagRegexp);
+            if (tagMatches &&
+                tagMatches[1] == branchMatches[1] &&
+                tagMatches[2] == branchMatches[2] &&
+                tagMatches[3] == '0') {
+                return 'true';
+            }
+        }
+    }
+    return 'false';
+}
+exports.hasMatchingReleaseTagWithRefNames = hasMatchingReleaseTagWithRefNames;
+//# sourceMappingURL=hasMatchingReleaseTag.js.map

--- a/has-matching-release-tag/hasMatchingReleaseTag.test.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.test.ts
@@ -1,0 +1,62 @@
+import { filterRefNames, hasMatchingReleaseTagWithRefNames } from './hasMatchingReleaseTag'
+
+const refNames = ['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release']
+const releaseTagRegexp = new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$')
+
+const releaseBranchWithoutPatchRegexp = new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$')
+const releaseBranchWithPatchRegexp = new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$')
+test('filterRefNames', () => {
+	expect(filterRefNames(refNames, releaseTagRegexp)).toStrictEqual(['v1.0.0', 'v1.0.1'])
+})
+
+test('hasMatchingReleaseTagWithRefNames', () => {
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			refNames,
+			'v1.0.0',
+			releaseTagRegexp,
+			releaseBranchWithoutPatchRegexp,
+			releaseBranchWithPatchRegexp,
+		),
+	).toBe('true')
+
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			refNames,
+			'release-1.0',
+			releaseTagRegexp,
+			releaseBranchWithoutPatchRegexp,
+			releaseBranchWithPatchRegexp,
+		),
+	).toBe('true')
+
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			refNames,
+			'release-1.0.1',
+			releaseTagRegexp,
+			releaseBranchWithoutPatchRegexp,
+			releaseBranchWithPatchRegexp,
+		),
+	).toBe('true')
+
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			refNames,
+			'release-1.1',
+			releaseTagRegexp,
+			releaseBranchWithoutPatchRegexp,
+			releaseBranchWithPatchRegexp,
+		),
+	).toBe('false')
+
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			refNames,
+			'release-2.0.0',
+			releaseTagRegexp,
+			releaseBranchWithoutPatchRegexp,
+			releaseBranchWithPatchRegexp,
+		),
+	).toBe('false')
+})

--- a/has-matching-release-tag/hasMatchingReleaseTag.test.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.test.ts
@@ -1,62 +1,72 @@
 import { filterRefNames, hasMatchingReleaseTagWithRefNames } from './hasMatchingReleaseTag'
 
-const refNames = ['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release']
-const releaseTagRegexp = new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$')
-
-const releaseBranchWithoutPatchRegexp = new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$')
-const releaseBranchWithPatchRegexp = new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$')
 test('filterRefNames', () => {
-	expect(filterRefNames(refNames, releaseTagRegexp)).toStrictEqual(['v1.0.0', 'v1.0.1'])
+	expect(
+		filterRefNames(
+			['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release'],
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+		),
+	).toStrictEqual(['v1.0.0', 'v1.0.1'])
 })
 
 test('hasMatchingReleaseTagWithRefNames', () => {
 	expect(
 		hasMatchingReleaseTagWithRefNames(
-			refNames,
-			'v1.0.0',
-			releaseTagRegexp,
-			releaseBranchWithoutPatchRegexp,
-			releaseBranchWithPatchRegexp,
-		),
-	).toBe('true')
-
-	expect(
-		hasMatchingReleaseTagWithRefNames(
-			refNames,
+			['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release'],
 			'release-1.0',
-			releaseTagRegexp,
-			releaseBranchWithoutPatchRegexp,
-			releaseBranchWithPatchRegexp,
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+		),
+	).toBe('true')
+
+	// Not providing the releaseBranchWithPatch regexp.
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release'],
+			'release-1.0',
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
 		),
 	).toBe('true')
 
 	expect(
 		hasMatchingReleaseTagWithRefNames(
-			refNames,
+			['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release'],
+			'v1.0.0',
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+		),
+	).toBe('true')
+
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release'],
 			'release-1.0.1',
-			releaseTagRegexp,
-			releaseBranchWithoutPatchRegexp,
-			releaseBranchWithPatchRegexp,
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
 		),
 	).toBe('true')
 
 	expect(
 		hasMatchingReleaseTagWithRefNames(
-			refNames,
+			['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release'],
 			'release-1.1',
-			releaseTagRegexp,
-			releaseBranchWithoutPatchRegexp,
-			releaseBranchWithPatchRegexp,
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
 		),
 	).toBe('false')
 
 	expect(
 		hasMatchingReleaseTagWithRefNames(
-			refNames,
+			['v1.0.0', 'v1.0.1', 'release-1.0.0', 'release-1.0.1', 'not-release'],
 			'release-2.0.0',
-			releaseTagRegexp,
-			releaseBranchWithoutPatchRegexp,
-			releaseBranchWithPatchRegexp,
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
 		),
 	).toBe('false')
 })

--- a/has-matching-release-tag/hasMatchingReleaseTag.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.ts
@@ -1,0 +1,77 @@
+import { exec, ExecOptions } from '@actions/exec'
+
+export async function hasMatchingReleaseTag(
+	refName: string,
+	releaseTagRegexp: RegExp,
+	releaseBranchWithoutPatchRegexp: RegExp,
+	releaseBranchWithPatchRegexp: RegExp,
+): Promise<string> {
+	let refNames: Array<string> = []
+	const options: ExecOptions = {
+		listeners: {
+			stdout: (data: Buffer) => {
+				refNames = data.toString().split(/(?:\r\n|\r|\n)/g)
+			},
+		},
+	}
+
+	await exec('git', ['tag'], options)
+
+	return hasMatchingReleaseTagWithRefNames(
+		refNames,
+		refName,
+		releaseTagRegexp,
+		releaseBranchWithoutPatchRegexp,
+		releaseBranchWithPatchRegexp,
+	)
+}
+
+export function filterRefNames(refNames: Array<string>, regexp: RegExp): Array<string> {
+	return refNames.filter((name) => name.match(regexp))
+}
+
+export function hasMatchingReleaseTagWithRefNames(
+	refNames: Array<string>,
+	refName: string,
+	releaseTagRegexp: RegExp,
+	releaseBranchWithoutPatchRegexp: RegExp,
+	releaseBranchWithPatchRegexp: RegExp,
+): string {
+	if (refName.match(releaseTagRegexp)) {
+		return 'true'
+	}
+
+	let releaseTags = filterRefNames(refNames, releaseTagRegexp)
+
+	let branchMatches = refName.match(releaseBranchWithPatchRegexp)
+	if (branchMatches) {
+		for (var i = 0; i < releaseTags.length; i++) {
+			let tagMatches = releaseTags[i].match(releaseTagRegexp)
+			if (
+				tagMatches &&
+				tagMatches[1] == branchMatches[1] &&
+				tagMatches[2] == branchMatches[2] &&
+				tagMatches[3] == branchMatches[3]
+			) {
+				return 'true'
+			}
+		}
+	}
+
+	branchMatches = refName.match(releaseBranchWithoutPatchRegexp)
+	if (branchMatches) {
+		for (var i = 0; i < releaseTags.length; i++) {
+			let tagMatches = releaseTags[i].match(releaseTagRegexp)
+			if (
+				tagMatches &&
+				tagMatches[1] == branchMatches[1] &&
+				tagMatches[2] == branchMatches[2] &&
+				tagMatches[3] == '0'
+			) {
+				return 'true'
+			}
+		}
+	}
+
+	return 'false'
+}

--- a/has-matching-release-tag/hasMatchingReleaseTag.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.ts
@@ -6,8 +6,12 @@ export function hasMatchingReleaseTag(
 	releaseBranchRegexp: RegExp,
 	releaseBranchWithPatchRegexp: RegExp | undefined,
 ): string {
+	let refNames = execFileSync('git', ['tag'], { encoding: 'utf8' }).split(/(?:\r\n|\r|\n)/g)
+	if (refNames.length == 0) {
+		throw 'No tags found. Is there an `actions/checkout` step with `fetch-depth: 0` before this action? https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches'
+	}
 	return hasMatchingReleaseTagWithRefNames(
-		execFileSync('git', ['tag'], { encoding: 'utf8' }).split(/(?:\r\n|\r|\n)/g),
+		refNames,
 		refName,
 		releaseTagRegexp,
 		releaseBranchRegexp,

--- a/has-matching-release-tag/hasMatchingReleaseTag.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.ts
@@ -7,7 +7,7 @@ export function hasMatchingReleaseTag(
 	releaseBranchRegexp: RegExp,
 	releaseBranchWithPatchRegexp: RegExp | undefined,
 ): string {
-	let refNames = splitStringIntoLines(execFileSync('git', ['tag'], { encoding: 'utf8' }))
+	let refNames = splitStringIntoLines(execFileSync('git', ['tag'], { encoding: 'utf8' })).filter((e) => e)
 	if (refNames.length == 0) {
 		throw 'No tags found. Is there an `actions/checkout` step with `fetch-depth: 0` before this action? https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches'
 	}

--- a/has-matching-release-tag/hasMatchingReleaseTag.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'child_process'
+import { splitStringIntoLines } from '../common/utils'
 
 export function hasMatchingReleaseTag(
 	refName: string,
@@ -6,7 +7,7 @@ export function hasMatchingReleaseTag(
 	releaseBranchRegexp: RegExp,
 	releaseBranchWithPatchRegexp: RegExp | undefined,
 ): string {
-	let refNames = execFileSync('git', ['tag'], { encoding: 'utf8' }).split(/(?:\r\n|\r|\n)/g)
+	let refNames = splitStringIntoLines(execFileSync('git', ['tag'], { encoding: 'utf8' }))
 	if (refNames.length == 0) {
 		throw 'No tags found. Is there an `actions/checkout` step with `fetch-depth: 0` before this action? https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches'
 	}

--- a/has-matching-release-tag/hasMatchingReleaseTag.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.ts
@@ -43,6 +43,7 @@ export function hasMatchingReleaseTagWithRefNames(
 	releaseBranchWithPatchRegexp: RegExp | undefined,
 ): string {
 	if (refName.match(releaseTagRegexp)) {
+		console.log(`Reference name is a release tag`)
 		return 'true'
 	}
 
@@ -58,6 +59,7 @@ export function hasMatchingReleaseTagWithRefNames(
 				tagMatches[2] == branchMatches[2] &&
 				tagMatches[3] == '0'
 			) {
+				console.log(`Found corresponding release tag for branch '${refName}': '${releaseTags[i]}'`)
 				return 'true'
 			}
 		}
@@ -74,11 +76,15 @@ export function hasMatchingReleaseTagWithRefNames(
 					tagMatches[2] == branchMatches[2] &&
 					tagMatches[3] == branchMatches[3]
 				) {
+					console.log(
+						`Found corresponding release tag for branch '${refName}': '${releaseTags[i]}'`,
+					)
 					return 'true'
 				}
 			}
 		}
 	}
 
+	console.log(`Found corresponding release tag for reference '${refName}'`)
 	return 'false'
 }

--- a/has-matching-release-tag/hasMatchingReleaseTag.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.ts
@@ -85,6 +85,6 @@ export function hasMatchingReleaseTagWithRefNames(
 		}
 	}
 
-	console.log(`Found corresponding release tag for reference '${refName}'`)
+	console.log(`Did not find a corresponding release tag for reference '${refName}'`)
 	return 'false'
 }

--- a/has-matching-release-tag/index.js
+++ b/has-matching-release-tag/index.js
@@ -3,19 +3,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core_1 = require("@actions/core");
 const utils_1 = require("../common/utils");
 const hasMatchingReleaseTag_1 = require("./hasMatchingReleaseTag");
-(async () => {
-    try {
-        let refName = (0, utils_1.getRequiredInput)('ref_name');
-        console.log('Input ref_name: ' + refName);
-        let releaseTagRegexp = new RegExp((0, utils_1.getRequiredInput)('release_tag_regexp'));
-        let releaseBranchWithoutPatchRegexp = new RegExp((0, utils_1.getRequiredInput)('release_branch_without_patch_regexp'));
-        let releaseBranchWithPatchRegexp = new RegExp((0, utils_1.getRequiredInput)('release_branch_with_patch_regexp'));
-        let bool = await (0, hasMatchingReleaseTag_1.hasMatchingReleaseTag)(refName, releaseTagRegexp, releaseBranchWithoutPatchRegexp, releaseBranchWithPatchRegexp);
-        console.log('Output bool: ' + bool);
-        (0, core_1.setOutput)('bool', bool);
-    }
-    catch (error) {
-        (0, core_1.setFailed)(error);
-    }
-})();
+try {
+    let refName = (0, utils_1.getRequiredInput)('ref_name');
+    console.log('Input ref_name: ' + refName);
+    let withPath = (0, utils_1.getInput)('release_branch_with_patch_regexp');
+    let bool = (0, hasMatchingReleaseTag_1.hasMatchingReleaseTag)(refName, new RegExp((0, utils_1.getRequiredInput)('release_tag_regexp')), new RegExp((0, utils_1.getRequiredInput)('release_branch_regexp')), withPath ? new RegExp(withPath) : undefined);
+    console.log('Output bool: ' + bool);
+    (0, core_1.setOutput)('bool', bool);
+}
+catch (error) {
+    (0, core_1.setFailed)(error);
+}
 //# sourceMappingURL=index.js.map

--- a/has-matching-release-tag/index.js
+++ b/has-matching-release-tag/index.js
@@ -3,6 +3,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core_1 = require("@actions/core");
 const utils_1 = require("../common/utils");
 const hasMatchingReleaseTag_1 = require("./hasMatchingReleaseTag");
+function prefixLines(prefix, lines) {
+    return lines.map((l) => `${prefix}${l}`);
+}
 try {
     let refName = (0, utils_1.getRequiredInput)('ref_name');
     console.log('Input ref_name: ' + refName);
@@ -12,6 +15,18 @@ try {
     (0, core_1.setOutput)('bool', bool);
 }
 catch (error) {
+    // Failed to spawn child process from execFileSync call.
+    if (error.code) {
+        (0, core_1.setFailed)(error.code);
+    }
+    // Child was spawned but exited with non-zero exit code.
+    if (error.stdout || error.stderr) {
+        const { stdout, stderr } = error;
+        (0, core_1.setFailed)(prefixLines('stdout: ', (0, utils_1.splitStringIntoLines)(stdout))
+            .concat(prefixLines('stderr: ', (0, utils_1.splitStringIntoLines)(stderr)))
+            .join('\n'));
+    }
+    // Some other error was thrown.
     (0, core_1.setFailed)(error);
 }
 //# sourceMappingURL=index.js.map

--- a/has-matching-release-tag/index.js
+++ b/has-matching-release-tag/index.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const core_1 = require("@actions/core");
+const utils_1 = require("../common/utils");
+const hasMatchingReleaseTag_1 = require("./hasMatchingReleaseTag");
+(async () => {
+    try {
+        let refName = (0, utils_1.getRequiredInput)('ref_name');
+        console.log('Input ref_name: ' + refName);
+        let releaseTagRegexp = new RegExp((0, utils_1.getRequiredInput)('release_tag_regexp'));
+        let releaseBranchWithoutPatchRegexp = new RegExp((0, utils_1.getRequiredInput)('release_branch_without_patch_regexp'));
+        let releaseBranchWithPatchRegexp = new RegExp((0, utils_1.getRequiredInput)('release_branch_with_patch_regexp'));
+        let bool = await (0, hasMatchingReleaseTag_1.hasMatchingReleaseTag)(refName, releaseTagRegexp, releaseBranchWithoutPatchRegexp, releaseBranchWithPatchRegexp);
+        console.log('Output bool: ' + bool);
+        (0, core_1.setOutput)('bool', bool);
+    }
+    catch (error) {
+        (0, core_1.setFailed)(error);
+    }
+})();
+//# sourceMappingURL=index.js.map

--- a/has-matching-release-tag/index.ts
+++ b/has-matching-release-tag/index.ts
@@ -1,0 +1,25 @@
+import { setOutput, setFailed } from '@actions/core'
+import { getRequiredInput } from '../common/utils'
+import { hasMatchingReleaseTag } from './hasMatchingReleaseTag'
+;(async () => {
+	try {
+		let refName = getRequiredInput('ref_name')
+		console.log('Input ref_name: ' + refName)
+		let releaseTagRegexp = new RegExp(getRequiredInput('release_tag_regexp'))
+		let releaseBranchWithoutPatchRegexp = new RegExp(
+			getRequiredInput('release_branch_without_patch_regexp'),
+		)
+		let releaseBranchWithPatchRegexp = new RegExp(getRequiredInput('release_branch_with_patch_regexp'))
+
+		let bool = await hasMatchingReleaseTag(
+			refName,
+			releaseTagRegexp,
+			releaseBranchWithoutPatchRegexp,
+			releaseBranchWithPatchRegexp,
+		)
+		console.log('Output bool: ' + bool)
+		setOutput('bool', bool)
+	} catch (error: any) {
+		setFailed(error)
+	}
+})()

--- a/has-matching-release-tag/index.ts
+++ b/has-matching-release-tag/index.ts
@@ -1,25 +1,20 @@
 import { setOutput, setFailed } from '@actions/core'
-import { getRequiredInput } from '../common/utils'
+import { getInput, getRequiredInput } from '../common/utils'
 import { hasMatchingReleaseTag } from './hasMatchingReleaseTag'
-;(async () => {
-	try {
-		let refName = getRequiredInput('ref_name')
-		console.log('Input ref_name: ' + refName)
-		let releaseTagRegexp = new RegExp(getRequiredInput('release_tag_regexp'))
-		let releaseBranchWithoutPatchRegexp = new RegExp(
-			getRequiredInput('release_branch_without_patch_regexp'),
-		)
-		let releaseBranchWithPatchRegexp = new RegExp(getRequiredInput('release_branch_with_patch_regexp'))
 
-		let bool = await hasMatchingReleaseTag(
-			refName,
-			releaseTagRegexp,
-			releaseBranchWithoutPatchRegexp,
-			releaseBranchWithPatchRegexp,
-		)
-		console.log('Output bool: ' + bool)
-		setOutput('bool', bool)
-	} catch (error: any) {
-		setFailed(error)
-	}
-})()
+try {
+	let refName = getRequiredInput('ref_name')
+	console.log('Input ref_name: ' + refName)
+
+	let withPath = getInput('release_branch_with_patch_regexp')
+	let bool = hasMatchingReleaseTag(
+		refName,
+		new RegExp(getRequiredInput('release_tag_regexp')),
+		new RegExp(getRequiredInput('release_branch_regexp')),
+		withPath ? new RegExp(withPath) : undefined,
+	)
+	console.log('Output bool: ' + bool)
+	setOutput('bool', bool)
+} catch (error: any) {
+	setFailed(error)
+}


### PR DESCRIPTION
Produce a boolean output that has the value "true" if and only if there is a release tag that
    matches the release branch.
    If the provided `ref_name` is a release tag reference, the output value is "true".
    If the provided `ref_name` is a release branch reference, the output value is "true" if
    and only if there is a matching release tag as defined by the `release_tag_regexp`.
    For release branches with a patch version, the capture groups for major, minor, and patch
    versions must match between the `release_branch_with_patch_regexp` and the
    `release_tag_regexp`.
    For release branches without a patch version, the capture groups for major and minor
    versions must match between the `release_branch_without_patch_regexp` and the
    `release_tag_regexp` and the release tag must have a `0` patch version.
    
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>