### PR TITLE
Adds support for a label PR check

### DIFF
--- a/pr-checks/checks/LabelCheck.js
+++ b/pr-checks/checks/LabelCheck.js
@@ -1,0 +1,77 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.stringMatchesLabel = exports.LabelCheck = exports.defaultConfig = void 0;
+const github_1 = require("@actions/github");
+const Check_1 = require("../Check");
+exports.defaultConfig = {
+    title: 'Label Check',
+    exists: 'Check success',
+    notExists: `Check failure`,
+    skipped: 'Check skipped',
+};
+class LabelCheck extends Check_1.Check {
+    constructor(config) {
+        super();
+        this.config = config;
+        this.id = 'label';
+    }
+    subscribe(s) {
+        s.on(['pull_request', 'pull_request_target'], ['labeled', 'unlabeled', 'opened', 'reopened', 'ready_for_review', 'synchronize'], async (ctx) => {
+            const payload = github_1.context.payload;
+            if (!payload) {
+                return;
+            }
+            if (payload.pull_request.state !== 'open') {
+                return;
+            }
+            for (let n = 0; n < payload.pull_request.labels.length; n++) {
+                const existingLabel = payload.pull_request.labels[n];
+                for (let i = 0; i < this.config.labels.matches.length; i++) {
+                    if (stringMatchesLabel(this.config.labels.matches[i], existingLabel.name)) {
+                        return this.successEnabled(ctx, payload.pull_request.head.sha);
+                    }
+                }
+            }
+            if (this.config.skip) {
+                for (let n = 0; n < payload.pull_request.labels.length; n++) {
+                    const existingLabel = payload.pull_request.labels[n];
+                    for (let i = 0; i < this.config.skip.matches.length; i++) {
+                        if (stringMatchesLabel(this.config.skip.matches[i], existingLabel.name)) {
+                            return this.successSkip(ctx, payload.pull_request.head.sha);
+                        }
+                    }
+                }
+            }
+            return this.failure(ctx, payload.pull_request.head.sha);
+        });
+    }
+    successEnabled(ctx, sha) {
+        const title = this.config.title ?? exports.defaultConfig.title;
+        const description = this.config.labels.exists ?? exports.defaultConfig.exists;
+        return ctx.success({ sha, title, description, targetURL: this.config.targetUrl });
+    }
+    successSkip(ctx, sha) {
+        const title = this.config.title ?? exports.defaultConfig.title;
+        const description = this.config.skip?.message ?? exports.defaultConfig.skipped;
+        return ctx.success({ sha, title, description, targetURL: this.config.targetUrl });
+    }
+    failure(ctx, sha) {
+        const title = this.config.title ?? exports.defaultConfig.title;
+        const description = this.config.labels.notExists ?? exports.defaultConfig.notExists;
+        return ctx.failure({ sha, title, description, targetURL: this.config.targetUrl });
+    }
+}
+exports.LabelCheck = LabelCheck;
+function stringMatchesLabel(str, label) {
+    str = str.trim();
+    if (str === '') {
+        return false;
+    }
+    if (str === '*') {
+        return true;
+    }
+    const lastAnyCharIndex = str.lastIndexOf('*');
+    return (lastAnyCharIndex !== -1 && label.startsWith(str.substring(0, lastAnyCharIndex))) || str === label;
+}
+exports.stringMatchesLabel = stringMatchesLabel;
+//# sourceMappingURL=LabelCheck.js.map

--- a/pr-checks/checks/LabelCheck.test.ts
+++ b/pr-checks/checks/LabelCheck.test.ts
@@ -1,0 +1,336 @@
+import { context } from '@actions/github'
+import { EventPayloads } from '@octokit/webhooks'
+import { expect } from 'chai'
+import { Dispatcher } from '../Dispatcher'
+import { CheckState } from '../types'
+import { LabelCheck, defaultConfig, stringMatchesLabel } from './LabelCheck'
+
+function mockAPI() {
+	return {
+		getPullRequest: jest.fn(),
+		createStatus: jest.fn(),
+		listStatusesByRef: jest.fn(),
+	}
+}
+
+const eventsAndActions = [
+	{
+		eventName: 'pull_request',
+		action: 'labeled',
+	},
+	{
+		eventName: 'pull_request',
+		action: 'unlabeled',
+	},
+	{
+		eventName: 'pull_request',
+		action: 'opened',
+	},
+	{
+		eventName: 'pull_request',
+		action: 'reopened',
+	},
+	{
+		eventName: 'pull_request',
+		action: 'ready_for_review',
+	},
+	{
+		eventName: 'pull_request',
+		action: 'synchronize',
+	},
+	{
+		eventName: 'pull_request_target',
+		action: 'labeled',
+	},
+	{
+		eventName: 'pull_request_target',
+		action: 'unlabeled',
+	},
+	{
+		eventName: 'pull_request_target',
+		action: 'opened',
+	},
+	{
+		eventName: 'pull_request_target',
+		action: 'reopened',
+	},
+	{
+		eventName: 'pull_request_target',
+		action: 'ready_for_review',
+	},
+	{
+		eventName: 'pull_request_target',
+		action: 'synchronize',
+	},
+]
+
+describe('LabelCheck', () => {
+	describe('Pull request closed', () => {
+		test.each(eventsAndActions)(
+			'$eventName - $action - Should not create status',
+			async ({ eventName, action }) => {
+				const api = mockAPI()
+				const d = new Dispatcher({
+					createStatus: api.createStatus,
+					getPullRequest: api.getPullRequest,
+				})
+				const c = new LabelCheck({ labels: { matches: ['test'] } })
+				c.subscribe(d)
+				context.eventName = eventName
+				context.payload = {
+					action: action,
+				}
+				context.payload.pull_request = {
+					state: 'closed',
+				} as EventPayloads.WebhookPayloadPullRequestPullRequest
+				await d.dispatch(context)
+
+				expect(api.getPullRequest.mock.calls.length).to.equal(0)
+				expect(api.createStatus.mock.calls.length).to.equal(0)
+			},
+		)
+	})
+
+	describe('No skip labels|Not matching label', () => {
+		test.each(eventsAndActions)(
+			'$eventName - $action - Should create status failure with not exists message',
+			async ({ eventName, action }) => {
+				const api = mockAPI()
+				const d = new Dispatcher({
+					createStatus: api.createStatus,
+					getPullRequest: api.getPullRequest,
+				})
+				const c = new LabelCheck({ labels: { matches: ['backport v*'] }, skip: { matches: [] } })
+				c.subscribe(d)
+				context.eventName = eventName
+				context.payload = {
+					action: action,
+				}
+				context.payload.pull_request = {
+					state: 'open',
+					labels: [
+						{ name: 'add to changelog' },
+						{ name: 'backport' },
+						{ name: 'backport ' },
+						{ name: 'no-backport' },
+					],
+					head: {
+						sha: '123',
+					},
+				} as EventPayloads.WebhookPayloadPullRequestPullRequest
+				await d.dispatch(context)
+
+				expect(api.getPullRequest.mock.calls.length).to.equal(0)
+				expect(api.createStatus.mock.calls.length).to.equal(1)
+				expect(api.createStatus.mock.calls[0][0]).to.equal('123')
+				expect(api.createStatus.mock.calls[0][1]).to.equal(defaultConfig.title)
+				expect(api.createStatus.mock.calls[0][2]).to.equal(CheckState.Failure)
+				expect(api.createStatus.mock.calls[0][3]).to.equal(defaultConfig.notExists)
+			},
+		)
+	})
+
+	describe('No skip labels|Matching label', () => {
+		test.each(eventsAndActions)(
+			'$eventName - $action - Should create status success with exists message',
+			async ({ eventName, action }) => {
+				const api = mockAPI()
+				const d = new Dispatcher({
+					createStatus: api.createStatus,
+					getPullRequest: api.getPullRequest,
+				})
+				const c = new LabelCheck({ labels: { matches: ['backport v*'] } })
+				c.subscribe(d)
+				context.eventName = eventName
+				context.payload = {
+					action,
+				}
+				context.payload.pull_request = {
+					state: 'open',
+					labels: [
+						{ name: 'add to changelog' },
+						{ name: 'backport' },
+						{ name: 'backport v7.2.x' },
+						{ name: 'no-backport' },
+					],
+					head: {
+						sha: '123',
+					},
+				} as EventPayloads.WebhookPayloadPullRequestPullRequest
+				await d.dispatch(context)
+
+				expect(api.getPullRequest.mock.calls.length).to.equal(0)
+				expect(api.createStatus.mock.calls.length).to.equal(1)
+				expect(api.createStatus.mock.calls[0][0]).to.equal('123')
+				expect(api.createStatus.mock.calls[0][1]).to.equal(defaultConfig.title)
+				expect(api.createStatus.mock.calls[0][2]).to.equal(CheckState.Success)
+				expect(api.createStatus.mock.calls[0][3]).to.equal(defaultConfig.exists)
+			},
+		)
+	})
+
+	describe('One skip label set|Not matching label, matching skip label', () => {
+		test.each(eventsAndActions)(
+			'$eventName - $action - Should create status success with skip message',
+			async ({ eventName, action }) => {
+				const api = mockAPI()
+				const d = new Dispatcher({
+					createStatus: api.createStatus,
+					getPullRequest: api.getPullRequest,
+				})
+				const c = new LabelCheck({
+					labels: { matches: ['backport v*'] },
+					skip: { matches: ['backport'] },
+				})
+				c.subscribe(d)
+				context.eventName = eventName
+				context.payload = {
+					action: action,
+				}
+				context.payload.pull_request = {
+					state: 'open',
+					labels: [{ name: 'backport' }, { name: 'backport ' }, { name: 'no-backport' }],
+					head: {
+						sha: '123',
+					},
+				} as EventPayloads.WebhookPayloadPullRequestPullRequest
+				await d.dispatch(context)
+
+				expect(api.getPullRequest.mock.calls.length).to.equal(0)
+				expect(api.createStatus.mock.calls.length).to.equal(1)
+				expect(api.createStatus.mock.calls[0][0]).to.equal('123')
+				expect(api.createStatus.mock.calls[0][1]).to.equal(defaultConfig.title)
+				expect(api.createStatus.mock.calls[0][2]).to.equal(CheckState.Success)
+				expect(api.createStatus.mock.calls[0][3]).to.equal(defaultConfig.skipped)
+			},
+		)
+	})
+
+	describe('Two skip labels set|Not matching label, matching skip label', () => {
+		test.each(eventsAndActions)(
+			'$eventName - $action - Should create status success with skip message',
+			async ({ eventName, action }) => {
+				const api = mockAPI()
+				const d = new Dispatcher({
+					createStatus: api.createStatus,
+					getPullRequest: api.getPullRequest,
+				})
+				const c = new LabelCheck({
+					labels: { matches: ['backport v*'] },
+					skip: { matches: ['backport', 'no-backport'] },
+				})
+				c.subscribe(d)
+				context.eventName = eventName
+				context.payload = {
+					action: action,
+				}
+				context.payload.pull_request = {
+					state: 'open',
+					labels: [{ name: 'add to changelog' }, { name: 'backport ' }, { name: 'no-backport' }],
+					head: {
+						sha: '123',
+					},
+				} as EventPayloads.WebhookPayloadPullRequestPullRequest
+				await d.dispatch(context)
+
+				expect(api.getPullRequest.mock.calls.length).to.equal(0)
+				expect(api.createStatus.mock.calls.length).to.equal(1)
+				expect(api.createStatus.mock.calls[0][0]).to.equal('123')
+				expect(api.createStatus.mock.calls[0][1]).to.equal(defaultConfig.title)
+				expect(api.createStatus.mock.calls[0][2]).to.equal(CheckState.Success)
+				expect(api.createStatus.mock.calls[0][3]).to.equal(defaultConfig.skipped)
+			},
+		)
+	})
+
+	describe('One skip label set|Matching label, matching skip label', () => {
+		test.each(eventsAndActions)(
+			'$eventName - $action - Should create status success with exists message',
+			async ({ eventName, action }) => {
+				const api = mockAPI()
+				const d = new Dispatcher({
+					createStatus: api.createStatus,
+					getPullRequest: api.getPullRequest,
+				})
+				const c = new LabelCheck({
+					labels: { matches: ['backport v*'] },
+					skip: { matches: ['backport'] },
+				})
+				c.subscribe(d)
+				context.eventName = eventName
+				context.payload = {
+					action: action,
+				}
+				context.payload.pull_request = {
+					state: 'open',
+					labels: [{ name: 'backport' }, { name: 'backport v8.3.x' }, { name: 'no-backport' }],
+					head: {
+						sha: '123',
+					},
+				} as EventPayloads.WebhookPayloadPullRequestPullRequest
+				await d.dispatch(context)
+
+				expect(api.getPullRequest.mock.calls.length).to.equal(0)
+				expect(api.createStatus.mock.calls.length).to.equal(1)
+				expect(api.createStatus.mock.calls[0][0]).to.equal('123')
+				expect(api.createStatus.mock.calls[0][1]).to.equal(defaultConfig.title)
+				expect(api.createStatus.mock.calls[0][2]).to.equal(CheckState.Success)
+				expect(api.createStatus.mock.calls[0][3]).to.equal(defaultConfig.exists)
+			},
+		)
+	})
+
+	describe('Two skip labels set|Matching label, matching skip label', () => {
+		test.each(eventsAndActions)(
+			'$eventName - $action - Should create status success with exists message',
+			async ({ eventName, action }) => {
+				const api = mockAPI()
+				const d = new Dispatcher({
+					createStatus: api.createStatus,
+					getPullRequest: api.getPullRequest,
+				})
+				const c = new LabelCheck({
+					labels: { matches: ['backport v*'] },
+					skip: { matches: ['backport', 'no-backport'] },
+				})
+				c.subscribe(d)
+				context.eventName = eventName
+				context.payload = {
+					action: action,
+				}
+				context.payload.pull_request = {
+					state: 'open',
+					labels: [
+						{ name: 'add to changelog' },
+						{ name: 'backport v10.0.x' },
+						{ name: 'no-backport' },
+					],
+					head: {
+						sha: '123',
+					},
+				} as EventPayloads.WebhookPayloadPullRequestPullRequest
+				await d.dispatch(context)
+
+				expect(api.getPullRequest.mock.calls.length).to.equal(0)
+				expect(api.createStatus.mock.calls.length).to.equal(1)
+				expect(api.createStatus.mock.calls[0][0]).to.equal('123')
+				expect(api.createStatus.mock.calls[0][1]).to.equal(defaultConfig.title)
+				expect(api.createStatus.mock.calls[0][2]).to.equal(CheckState.Success)
+				expect(api.createStatus.mock.calls[0][3]).to.equal(defaultConfig.exists)
+			},
+		)
+	})
+})
+
+describe('stringMatchesLabel', () => {
+	test.each([
+		{ str: '', label: 'abc', shouldMatch: false },
+		{ str: 'backport', label: 'backport v8.5.x', shouldMatch: false },
+		{ str: 'backport ', label: 'backport v8.5.x', shouldMatch: false },
+		{ str: '*', label: 'abc', shouldMatch: true },
+		{ str: 'backport v*', label: 'backport v8.5.x', shouldMatch: true },
+	])(`string='$str', label='$label', expected: $shouldMatch`, async ({ str, label, shouldMatch }) => {
+		const matches = stringMatchesLabel(str, label)
+		expect(matches).to.be.equal(shouldMatch)
+	})
+})

--- a/pr-checks/checks/LabelCheck.ts
+++ b/pr-checks/checks/LabelCheck.ts
@@ -1,0 +1,108 @@
+import { context } from '@actions/github'
+import { EventPayloads } from '@octokit/webhooks'
+import { Check } from '../Check'
+import { CheckContext, CheckSubscriber } from '../types'
+
+export type LabelCheckConfig = {
+	title?: string
+	targetUrl?: string
+	labels: {
+		exists?: string
+		notExists?: string
+		matches: string[]
+	}
+	skip?: {
+		message?: string
+		matches: string[]
+	}
+}
+
+export const defaultConfig = {
+	title: 'Label Check',
+	exists: 'Check success',
+	notExists: `Check failure`,
+	skipped: 'Check skipped',
+}
+
+export class LabelCheck extends Check {
+	id = 'label'
+
+	constructor(private config: LabelCheckConfig) {
+		super()
+	}
+
+	subscribe(s: CheckSubscriber) {
+		s.on(
+			['pull_request', 'pull_request_target'],
+			['labeled', 'unlabeled', 'opened', 'reopened', 'ready_for_review', 'synchronize'],
+			async (ctx) => {
+				const payload = context.payload as EventPayloads.WebhookPayloadPullRequest
+				if (!payload) {
+					return
+				}
+
+				if (payload.pull_request.state !== 'open') {
+					return
+				}
+
+				for (let n = 0; n < payload.pull_request.labels.length; n++) {
+					const existingLabel = payload.pull_request.labels[n]
+
+					for (let i = 0; i < this.config.labels.matches.length; i++) {
+						if (stringMatchesLabel(this.config.labels.matches[i], existingLabel.name)) {
+							return this.successEnabled(ctx, payload.pull_request.head.sha)
+						}
+					}
+				}
+
+				if (this.config.skip) {
+					for (let n = 0; n < payload.pull_request.labels.length; n++) {
+						const existingLabel = payload.pull_request.labels[n]
+
+						for (let i = 0; i < this.config.skip.matches.length; i++) {
+							if (stringMatchesLabel(this.config.skip.matches[i], existingLabel.name)) {
+								return this.successSkip(ctx, payload.pull_request.head.sha)
+							}
+						}
+					}
+				}
+
+				return this.failure(ctx, payload.pull_request.head.sha)
+			},
+		)
+	}
+
+	private successEnabled(ctx: CheckContext, sha: string) {
+		const title = this.config.title ?? defaultConfig.title
+		const description = this.config.labels.exists ?? defaultConfig.exists
+		return ctx.success({ sha, title, description, targetURL: this.config.targetUrl })
+	}
+
+	private successSkip(ctx: CheckContext, sha: string) {
+		const title = this.config.title ?? defaultConfig.title
+		const description = this.config.skip?.message ?? defaultConfig.skipped
+		return ctx.success({ sha, title, description, targetURL: this.config.targetUrl })
+	}
+
+	private failure(ctx: CheckContext, sha: string) {
+		const title = this.config.title ?? defaultConfig.title
+		const description = this.config.labels.notExists ?? defaultConfig.notExists
+		return ctx.failure({ sha, title, description, targetURL: this.config.targetUrl })
+	}
+}
+
+export function stringMatchesLabel(str: string, label: string) {
+	str = str.trim()
+
+	if (str === '') {
+		return false
+	}
+
+	if (str === '*') {
+		return true
+	}
+
+	const lastAnyCharIndex = str.lastIndexOf('*')
+
+	return (lastAnyCharIndex !== -1 && label.startsWith(str.substring(0, lastAnyCharIndex))) || str === label
+}

--- a/pr-checks/checks/index.js
+++ b/pr-checks/checks/index.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getChecks = void 0;
 const BackportCheck_1 = require("./BackportCheck");
+const LabelCheck_1 = require("./LabelCheck");
 const MilestoneCheck_1 = require("./MilestoneCheck");
 function getChecks(config) {
     const checks = [];
@@ -13,6 +14,9 @@ function getChecks(config) {
                 break;
             case 'check-backport':
                 checks.push(new BackportCheck_1.BackportCheck(checkConfig));
+                break;
+            case 'check-label':
+                checks.push(new LabelCheck_1.LabelCheck(checkConfig));
                 break;
         }
     }

--- a/pr-checks/checks/index.ts
+++ b/pr-checks/checks/index.ts
@@ -1,10 +1,12 @@
 import { Check } from '../Check'
 import { BackportCheck, BackportCheckConfig } from './BackportCheck'
+import { LabelCheck, LabelCheckConfig } from './LabelCheck'
 import { MilestoneCheck, MilestoneCheckConfig } from './MilestoneCheck'
 
 export type CheckConfig =
 	| ({ type: 'check-milestone' } & MilestoneCheckConfig)
 	| ({ type: 'check-backport' } & BackportCheckConfig)
+	| ({ type: 'check-label' } & LabelCheckConfig)
 
 export function getChecks(config: CheckConfig[]) {
 	const checks: Check[] = []
@@ -18,6 +20,9 @@ export function getChecks(config: CheckConfig[]) {
 				break
 			case 'check-backport':
 				checks.push(new BackportCheck(checkConfig))
+				break
+			case 'check-label':
+				checks.push(new LabelCheck(checkConfig))
 				break
 		}
 	}


### PR DESCRIPTION
Adds support for a new PR check named label check. Since very similar to the backport check the plan is to delete the backport check eventually and reuse the label check for multiple purposes, such as backport check and changelog check.

The idea is to configure it in the following way:
```json
[
  {
    "type": "check-label",
    "title": "Backport Check",
    "labels": {
      "exists": "Backport enabled",
      "notExists": "Backport decision needed",
      "matches": [
        "backport v*"
      ]
    },
    "skip": {
      "message": "Backport skipped",
      "matches": [
        "backport",
        "no-backport"
      ] 
    },
    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#should-the-pull-request-be-backported"
  },
  {
    "type": "check-label",
    "title": "Changelog Check",
    "labels": {
      "exists": "Changelog enabled",
      "notExists": "Changelog decision needed",
      "matches": [
        "add to changelog"
      ]
    },
    "skip": {
      "message": "Changelog skipped",
      "matches": [
        "no-changelog"
      ] 
    },
    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#should-the-pull-request-be-backported"
  }
]
```

Test: https://github.com/grafana/github-actions-testrepo/pull/71