### PR TITLE
PR Checks: Trigger milestone check on labeled/unlabeled actions

### DIFF
--- a/pr-checks/checks/MilestoneCheck.js
+++ b/pr-checks/checks/MilestoneCheck.js
@@ -10,7 +10,7 @@ class MilestoneCheck extends Check_1.Check {
         this.id = 'milestone';
     }
     subscribe(s) {
-        s.on(['pull_request', 'pull_request_target'], ['opened', 'reopened', 'ready_for_review', 'synchronize'], async (ctx) => {
+        s.on(['pull_request', 'pull_request_target'], ['opened', 'reopened', 'ready_for_review', 'synchronize', 'labeled', 'unlabeled'], async (ctx) => {
             const pr = github_1.context.payload.pull_request;
             if (pr && pr.milestone) {
                 return this.success(ctx, pr.head.sha);

--- a/pr-checks/checks/MilestoneCheck.test.ts
+++ b/pr-checks/checks/MilestoneCheck.test.ts
@@ -6,138 +6,38 @@ import { Dispatcher } from '../Dispatcher'
 import { CheckState } from '../types'
 import { MilestoneCheck } from './MilestoneCheck'
 
+const prEvents = ['pull_request', 'pull_request_target']
+const prActions = ['opened', 'reopened', 'ready_for_review', 'synchronize', 'labeled', 'unlabeled']
+
+const prTestCases = prEvents
+	.flatMap((event) => {
+		return prActions.map((action) => ({
+			eventName: event,
+			action: action,
+		}))
+	})
+	.flatMap((tc) => [
+		{
+			testCaseName: 'without milestone set',
+			eventName: tc.eventName,
+			action: tc.action,
+			checkState: CheckState.Failure,
+			description: 'Failed',
+			pull_request_payload: {},
+		},
+		{
+			testCaseName: 'with milestone set',
+			eventName: tc.eventName,
+			action: tc.action,
+			checkState: CheckState.Success,
+			description: 'Milestone set',
+			pull_request_payload: { milestone: {} },
+		},
+	])
+
 describe('MilestoneCheck', () => {
 	describe('Pull Requests', () => {
-		test.each([
-			{
-				testCaseName: 'without milestone set',
-				eventName: 'pull_request',
-				action: 'opened',
-				checkState: CheckState.Failure,
-				description: 'Failed',
-				pull_request_payload: {},
-			},
-			{
-				testCaseName: 'without milestone set',
-				eventName: 'pull_request',
-				action: 'reopened',
-				checkState: CheckState.Failure,
-				description: 'Failed',
-				pull_request_payload: {},
-			},
-			{
-				testCaseName: 'without milestone set',
-				eventName: 'pull_request',
-				action: 'synchronize',
-				checkState: CheckState.Failure,
-				description: 'Failed',
-				pull_request_payload: {},
-			},
-			{
-				testCaseName: 'without milestone set',
-				eventName: 'pull_request',
-				action: 'ready_for_review',
-				checkState: CheckState.Failure,
-				description: 'Failed',
-				pull_request_payload: {},
-			},
-			{
-				testCaseName: 'without milestone set',
-				eventName: 'pull_request_target',
-				action: 'opened',
-				checkState: CheckState.Failure,
-				description: 'Failed',
-				pull_request_payload: {},
-			},
-			{
-				testCaseName: 'without milestone set',
-				eventName: 'pull_request_target',
-				action: 'reopened',
-				checkState: CheckState.Failure,
-				description: 'Failed',
-				pull_request_payload: {},
-			},
-			{
-				testCaseName: 'without milestone set',
-				eventName: 'pull_request_target',
-				action: 'ready_for_review',
-				checkState: CheckState.Failure,
-				description: 'Failed',
-				pull_request_payload: {},
-			},
-			{
-				testCaseName: 'without milestone set',
-				eventName: 'pull_request_target',
-				action: 'synchronize',
-				checkState: CheckState.Failure,
-				description: 'Failed',
-				pull_request_payload: {},
-			},
-			{
-				testCaseName: 'with milestone set',
-				eventName: 'pull_request',
-				action: 'opened',
-				checkState: CheckState.Success,
-				description: 'Milestone set',
-				pull_request_payload: { milestone: {} },
-			},
-			{
-				testCaseName: 'with milestone set',
-				eventName: 'pull_request',
-				action: 'reopened',
-				checkState: CheckState.Success,
-				description: 'Milestone set',
-				pull_request_payload: { milestone: {} },
-			},
-			{
-				testCaseName: 'with milestone set',
-				eventName: 'pull_request',
-				action: 'ready_for_review',
-				checkState: CheckState.Success,
-				description: 'Milestone set',
-				pull_request_payload: { milestone: {} },
-			},
-			{
-				testCaseName: 'with milestone set',
-				eventName: 'pull_request',
-				action: 'synchronize',
-				checkState: CheckState.Success,
-				description: 'Milestone set',
-				pull_request_payload: { milestone: {} },
-			},
-			{
-				testCaseName: 'with milestone set',
-				eventName: 'pull_request_target',
-				action: 'opened',
-				checkState: CheckState.Success,
-				description: 'Milestone set',
-				pull_request_payload: { milestone: {} },
-			},
-			{
-				testCaseName: 'with milestone set',
-				eventName: 'pull_request_target',
-				action: 'reopened',
-				checkState: CheckState.Success,
-				description: 'Milestone set',
-				pull_request_payload: { milestone: {} },
-			},
-			{
-				testCaseName: 'with milestone set',
-				eventName: 'pull_request_target',
-				action: 'ready_for_review',
-				checkState: CheckState.Success,
-				description: 'Milestone set',
-				pull_request_payload: { milestone: {} },
-			},
-			{
-				testCaseName: 'with milestone set',
-				eventName: 'pull_request_target',
-				action: 'synchronize',
-				checkState: CheckState.Success,
-				description: 'Milestone set',
-				pull_request_payload: { milestone: {} },
-			},
-		])(
+		test.each(prTestCases)(
 			'$eventName - $action - $testCaseName - Should create status $checkState',
 			async ({ eventName, action, checkState, description, pull_request_payload }) => {
 				const createStatusMock = jest.fn()

--- a/pr-checks/checks/MilestoneCheck.ts
+++ b/pr-checks/checks/MilestoneCheck.ts
@@ -20,7 +20,7 @@ export class MilestoneCheck extends Check {
 	subscribe(s: CheckSubscriber) {
 		s.on(
 			['pull_request', 'pull_request_target'],
-			['opened', 'reopened', 'ready_for_review', 'synchronize'],
+			['opened', 'reopened', 'ready_for_review', 'synchronize', 'labeled', 'unlabeled'],
 			async (ctx) => {
 				const pr = context.payload.pull_request as EventPayloads.WebhookPayloadPullRequestPullRequest
 

--- a/repository-dispatch/index.ts
+++ b/repository-dispatch/index.ts
@@ -12,7 +12,7 @@ class RepositoryDispatch extends Action {
 			throw new Error('Missing repository')
 		}
 
-        const api = new OctoKit(this.getToken(), context.repo)
+		const api = new OctoKit(this.getToken(), context.repo)
 
 		const [owner, repo] = repository.split('/')
 


### PR DESCRIPTION
Improve logic in case milestoned event workflow run was cancelled so that milestone check run on labeled/unlabeled events as well. 

Reported problems with backports especially, e.g. https://github.com/grafana/grafana/pull/49573, with changelog and milestone check fails often.