### PR TITLE
Enterprise Check: handle newer OSS commits

### DIFF
--- a/enterprise-check/index.js
+++ b/enterprise-check/index.js
@@ -26,12 +26,22 @@ class EnterpriseCheck extends Action_1.Action {
                     throw new Error('error retrieving main branch');
                 }
             }
-            await octokit.octokit.git.createRef({
+            const res = await octokit.octokit.git.createRef({
                 owner: 'grafana',
                 repo: 'grafana-enterprise',
                 ref: `refs/heads/pr-check-${prNumber}/${sourceBranch}`,
                 sha: branch.commit.sha,
             });
+            // Branch already exists - need to update the branch to trigger a new build
+            if (res.status === 422) {
+                await octokit.octokit.git.updateRef({
+                    owner: 'grafana',
+                    repo: 'grafana-enterprise',
+                    ref: `refs/heads/pr-check-${prNumber}/${sourceBranch}`,
+                    sha: branch.commit.sha,
+                    force: true,
+                });
+            }
         }
     }
 }

--- a/enterprise-check/index.js
+++ b/enterprise-check/index.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const Action_1 = require("../common/Action");
 const core_1 = require("@actions/core");
+const request_error_1 = require("@octokit/request-error");
 class EnterpriseCheck extends Action_1.Action {
     constructor() {
         super(...arguments);
@@ -26,22 +27,7 @@ class EnterpriseCheck extends Action_1.Action {
                     throw new Error('error retrieving main branch');
                 }
             }
-            const res = await octokit.octokit.git.createRef({
-                owner: 'grafana',
-                repo: 'grafana-enterprise',
-                ref: `refs/heads/pr-check-${prNumber}/${sourceBranch}`,
-                sha: branch.commit.sha,
-            });
-            // Branch already exists - need to update the branch to trigger a new build
-            if (res.status === 422) {
-                await octokit.octokit.git.updateRef({
-                    owner: 'grafana',
-                    repo: 'grafana-enterprise',
-                    ref: `refs/heads/pr-check-${prNumber}/${sourceBranch}`,
-                    sha: branch.commit.sha,
-                    force: true,
-                });
-            }
+            await createOrUpdateRef(octokit, `refs/heads/pr-check-${prNumber}/${sourceBranch}`, branch.commit.sha);
         }
     }
 }
@@ -59,6 +45,30 @@ async function getBranch(octokit, branch) {
         console.log('err: ', err);
     }
     return null;
+}
+async function createOrUpdateRef(octokit, ref, sha) {
+    try {
+        await octokit.octokit.git.createRef({
+            owner: 'grafana',
+            repo: 'grafana-enterprise',
+            ref: ref,
+            sha: sha,
+        });
+    }
+    catch (err) {
+        if (err instanceof request_error_1.RequestError && err.message === 'Reference already exists') {
+            await octokit.octokit.git.updateRef({
+                owner: 'grafana',
+                repo: 'grafana-enterprise',
+                ref: ref,
+                sha: sha,
+                force: true,
+            });
+        }
+        else {
+            throw err;
+        }
+    }
 }
 new EnterpriseCheck().run(); // eslint-disable-line
 //# sourceMappingURL=index.js.map

--- a/enterprise-check/index.js
+++ b/enterprise-check/index.js
@@ -27,7 +27,7 @@ class EnterpriseCheck extends Action_1.Action {
                     throw new Error('error retrieving main branch');
                 }
             }
-            await createOrUpdateRef(octokit, `refs/heads/pr-check-${prNumber}/${sourceBranch}`, branch.commit.sha);
+            await createOrUpdateRef(octokit, prNumber, sourceBranch, branch.commit.sha);
         }
     }
 }
@@ -46,12 +46,12 @@ async function getBranch(octokit, branch) {
     }
     return null;
 }
-async function createOrUpdateRef(octokit, ref, sha) {
+async function createOrUpdateRef(octokit, prNumber, branch, sha) {
     try {
         await octokit.octokit.git.createRef({
             owner: 'grafana',
             repo: 'grafana-enterprise',
-            ref: ref,
+            ref: `refs/heads/pr-check-${prNumber}/${branch}`,
             sha: sha,
         });
     }
@@ -60,7 +60,7 @@ async function createOrUpdateRef(octokit, ref, sha) {
             await octokit.octokit.git.updateRef({
                 owner: 'grafana',
                 repo: 'grafana-enterprise',
-                ref: ref,
+                ref: `heads/pr-check-${prNumber}/${branch}`,
                 sha: sha,
                 force: true,
             });

--- a/enterprise-check/index.ts
+++ b/enterprise-check/index.ts
@@ -30,7 +30,11 @@ class EnterpriseCheck extends Action {
 				}
 			}
 
-			await createOrUpdateRef(octokit, `refs/heads/pr-check-${prNumber}/${sourceBranch}`, branch.commit.sha)
+			await createOrUpdateRef(
+				octokit,
+				`refs/heads/pr-check-${prNumber}/${sourceBranch}`,
+				branch.commit.sha,
+			)
 		}
 	}
 }

--- a/enterprise-check/index.ts
+++ b/enterprise-check/index.ts
@@ -30,11 +30,7 @@ class EnterpriseCheck extends Action {
 				}
 			}
 
-			await createOrUpdateRef(
-				octokit,
-				`refs/heads/pr-check-${prNumber}/${sourceBranch}`,
-				branch.commit.sha,
-			)
+			await createOrUpdateRef(octokit, prNumber, sourceBranch, branch.commit.sha)
 		}
 	}
 }
@@ -56,12 +52,12 @@ async function getBranch(octokit: OctoKit, branch: string): Promise<Octokit.Repo
 	return null
 }
 
-async function createOrUpdateRef(octokit: OctoKit, ref: string, sha: string) {
+async function createOrUpdateRef(octokit: OctoKit, prNumber: string, branch: string, sha: string) {
 	try {
 		await octokit.octokit.git.createRef({
 			owner: 'grafana',
 			repo: 'grafana-enterprise',
-			ref: ref,
+			ref: `refs/heads/pr-check-${prNumber}/${branch}`,
 			sha: sha,
 		})
 	} catch (err) {
@@ -69,7 +65,7 @@ async function createOrUpdateRef(octokit: OctoKit, ref: string, sha: string) {
 			await octokit.octokit.git.updateRef({
 				owner: 'grafana',
 				repo: 'grafana-enterprise',
-				ref: ref,
+				ref: `heads/pr-check-${prNumber}/${branch}`,
 				sha: sha,
 				force: true,
 			})

--- a/enterprise-check/index.ts
+++ b/enterprise-check/index.ts
@@ -29,12 +29,23 @@ class EnterpriseCheck extends Action {
 				}
 			}
 
-			await octokit.octokit.git.createRef({
+			const res = await octokit.octokit.git.createRef({
 				owner: 'grafana',
 				repo: 'grafana-enterprise',
 				ref: `refs/heads/pr-check-${prNumber}/${sourceBranch}`,
 				sha: branch.commit.sha,
 			})
+			
+			// Branch already exists - need to update the branch to trigger a new build
+			if (res.status === 422) {
+				await octokit.octokit.git.updateRef({
+					owner: 'grafana',
+					repo: 'grafana-enterprise',
+					ref: `refs/heads/pr-check-${prNumber}/${sourceBranch}`,
+					sha: branch.commit.sha,
+					force: true,
+				})
+			}
 		}
 	}
 }


### PR DESCRIPTION
Right now, when OSS commits are too close to each other and the first build isn't finished when a second commit is pushed, the Enterprise Check action can’t create the Enterprise branch (that already exists) and so can’t trigger multiple builds (failure example: https://github.com/grafana/grafana-enterprise/actions/runs/2332086035).

This can cause:
1. The developer needs to manually re-trigger the check if they made a fix for Enterprise in the second commit.
2. If the first commit doesn't break Enterprise but the second one does: we'll miss this breaking change.

This PR updates this GH action to update the branch if it already exists. This will then trigger a new Drone build.
However, the first build won't be cancelled by the new one as cancelling old builds on pushes is a global setting in Drone and we don't want this behavior on the `main` branch. 