### PR TITLE
Backport: explicitly point to betterer config file

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -44,7 +44,7 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
         return stdout.trim() === BETTERER_RESULTS_PATH;
     };
     const fixBettererConflict = async () => {
-        await (0, betterer_1.betterer)({ update: true });
+        await (0, betterer_1.betterer)({ update: true, configPaths: ['./.betterer.ts'] });
         await git('add', BETTERER_RESULTS_PATH);
         // Setting -c core.editor=true will prevent the commit message editor from opening
         await git('-c', 'core.editor=true', 'cherry-pick', '--continue');

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -92,7 +92,7 @@ const backportOnce = async ({
 	}
 
 	const fixBettererConflict = async () => {
-		await betterer({ update: true })
+		await betterer({ update: true, configPaths: ['./.betterer.ts'] })
 		await git('add', BETTERER_RESULTS_PATH)
 		// Setting -c core.editor=true will prevent the commit message editor from opening
 		await git('-c', 'core.editor=true', 'cherry-pick', '--continue')


### PR DESCRIPTION
can see it failing in this PR: https://github.com/grafana/grafana/pull/51563

i'll leave that PR there to retest when this is merged 😄 