### PR TITLE
Backport: Run yarn:build for #110

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -198,6 +198,13 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                     owner,
                     repo,
                 });
+                // Add backport-failed label to failed backports
+                await github.issues.addLabels({
+                    issue_number: pullRequestNumber,
+                    labels: ['backport-failed'],
+                    owner,
+                    repo,
+                });
             }
         });
     }


### PR DESCRIPTION
Forgot to run `yarn:build` for https://github.com/grafana/grafana-github-actions/pull/110.
There should be a CI step. Will create an issue for that.