### PR TITLE
Adding default lables to changelog PR

### DIFF
--- a/update-changelog/index.js
+++ b/update-changelog/index.js
@@ -75,7 +75,7 @@ class UpdateChangelog extends Action_1.Action {
         await git('add', '-A');
         await git('commit', '-m', `${title}`);
         await git('push', '--set-upstream', 'origin', branchName);
-        await octokit.octokit.pulls.create({
+        const pr = await octokit.octokit.pulls.create({
             base: 'main',
             body: 'This exciting! So much has changed!\nDO NOT CHANGE THE TITLES DIRECTLY IN THIS PR, everything in the PR is auto-generated.',
             head: branchName,
@@ -83,6 +83,14 @@ class UpdateChangelog extends Action_1.Action {
             repo,
             title,
         });
+        if (pr.data.number) {
+            await octokit.octokit.issues.addLabels({
+                issue_number: pr.data.number,
+                owner,
+                repo,
+                labels: ['no-backport', 'no-changelog'],
+            });
+        }
     }
 }
 const git = async (...args) => {

--- a/update-changelog/index.js
+++ b/update-changelog/index.js
@@ -18,6 +18,8 @@ class UpdateChangelog extends Action_1.Action {
         const { owner, repo } = github_1.context.repo;
         const token = this.getToken();
         const version = this.getVersion();
+        const versionSplitted = version.split('.');
+        const versionMajorBranch = 'v' + versionSplitted[0] + '.' + versionSplitted[1] + '.' + 'x';
         await (0, git_1.cloneRepo)({ token, owner, repo });
         process.chdir(repo);
         const fileUpdater = new FileUpdater_1.FileUpdater();
@@ -88,7 +90,7 @@ class UpdateChangelog extends Action_1.Action {
                 issue_number: pr.data.number,
                 owner,
                 repo,
-                labels: ['no-backport', 'no-changelog'],
+                labels: ['backport ' + versionMajorBranch, 'no-changelog'],
             });
         }
     }

--- a/update-changelog/index.ts
+++ b/update-changelog/index.ts
@@ -16,6 +16,8 @@ class UpdateChangelog extends Action {
 		const { owner, repo } = context.repo
 		const token = this.getToken()
 		const version = this.getVersion()
+		const versionSplitted = version.split('.')
+		const versionMajorBranch = 'v' + versionSplitted[0] + '.' + versionSplitted[1] + '.' + 'x'
 
 		await cloneRepo({ token, owner, repo })
 
@@ -114,7 +116,7 @@ class UpdateChangelog extends Action {
 				issue_number: pr.data.number,
 				owner,
 				repo,
-				labels: ['no-backport', 'no-changelog'],
+				labels: ['backport ' + versionMajorBranch, 'no-changelog'],
 			})
 		}
 	}

--- a/update-changelog/index.ts
+++ b/update-changelog/index.ts
@@ -100,7 +100,7 @@ class UpdateChangelog extends Action {
 		await git('commit', '-m', `${title}`)
 		await git('push', '--set-upstream', 'origin', branchName)
 
-		await octokit.octokit.pulls.create({
+		const pr = await octokit.octokit.pulls.create({
 			base: 'main',
 			body: 'This exciting! So much has changed!\nDO NOT CHANGE THE TITLES DIRECTLY IN THIS PR, everything in the PR is auto-generated.',
 			head: branchName,
@@ -108,6 +108,15 @@ class UpdateChangelog extends Action {
 			repo,
 			title,
 		})
+
+		if (pr.data.number) {
+			await octokit.octokit.issues.addLabels({
+				issue_number: pr.data.number,
+				owner,
+				repo,
+				labels: ['no-backport', 'no-changelog'],
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Based of PIR for Release 9.2.4, the changelog PR that is auto-generated has no default labels set. This PR adds the default labels. 

Example PR https://github.com/grafana/grafana/pull/58467 - you can see manually added labels in PR history