### PR TITLE
Backporting: Make `bug` or `product-approved` labels mandatory for backporting

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -141,7 +141,9 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
 };
 const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     let labelsString = labels.map(({ name }) => name);
-    if (!(labelsString.includes('bug') || labelsString.includes('product-approved'))) {
+    if (!(labelsString.includes('bug') ||
+        labelsString.includes('product-approved') ||
+        labelsString.includes('type/docs'))) {
         console.log('PR intended to be backported, but not labeled properly. Labels: ' +
             labelsString +
             '\n Author: ' +
@@ -151,9 +153,10 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                 'Hello ' + '@' + sender.login + '!',
                 'Backport pull requests need to be either:',
                 '* Pull requests which address bugs,',
-                '* Urgent fixes which need product approval, in order to get merged.\n',
+                '* Urgent fixes which need product approval, in order to get merged,',
+                '* Docs changes.\n',
                 'Please, if the current pull request addresses a bug fix, label it with the `bug` label.',
-                'If it already has the product approval, please add the `product-approved` label.',
+                'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label',
                 'If none of the above applies, please consider removing the backport label and target the next major/minor release.',
                 'Thanks!',
             ].join('\n'),

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -13,11 +13,12 @@ const git_1 = require("../common/git");
 const BETTERER_RESULTS_PATH = '.betterer.results';
 const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/;
 const getLabelNames = ({ action, label, labels, }) => {
+    let labelsString = labels.map(({ name }) => name);
     switch (action) {
         case 'closed':
             return labels.map(({ name }) => name);
         case 'labeled':
-            return [label.name];
+            return [label.name, ...labelsString];
         default:
             return [];
     }

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -141,7 +141,7 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
 };
 const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     let labelsString = labels.map(({ name }) => name);
-    if (!(labelsString.includes('bug') ||
+    if (!(labelsString.includes('type/bug') ||
         labelsString.includes('product-approved') ||
         labelsString.includes('type/docs'))) {
         console.log('PR intended to be backported, but not labeled properly. Labels: ' +
@@ -155,7 +155,7 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                 '* Pull requests which address bugs,',
                 '* Urgent fixes which need product approval, in order to get merged,',
                 '* Docs changes.\n',
-                'Please, if the current pull request addresses a bug fix, label it with the `bug` label.',
+                'Please, if the current pull request addresses a bug fix, label it with the `type/bug` label.',
                 'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label',
                 'If none of the above applies, please consider removing the backport label and target the next major/minor release.',
                 'Thanks!',

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -156,7 +156,7 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                 '* Urgent fixes which need product approval, in order to get merged,',
                 '* Docs changes.\n',
                 'Please, if the current pull request addresses a bug fix, label it with the `type/bug` label.',
-                'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label',
+                'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label.',
                 'If none of the above applies, please consider removing the backport label and target the next major/minor release.',
                 'Thanks!',
             ].join('\n'),

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -237,7 +237,7 @@ const backport = async ({
 	sender,
 }: BackportArgs) => {
 	let labelsString = labels.map(({ name }) => name)
-	if (!(labelsString.includes('bug') || labelsString.includes('product-approved'))) {
+	if (!(labelsString.includes('bug') || labelsString.includes('product-approved') || labelsString.includes('type/docs'))) {
 		console.log(
 			'PR intended to be backported, but not labeled properly. Labels: ' +
 				labelsString +
@@ -249,9 +249,10 @@ const backport = async ({
 				'Hello ' + '@' + sender.login + '!',
 				'Backport pull requests need to be either:',
 				'* Pull requests which address bugs,',
-				'* Urgent fixes which need product approval, in order to get merged.\n',
+				'* Urgent fixes which need product approval, in order to get merged,',
+				'* Docs changes.\n',
 				'Please, if the current pull request addresses a bug fix, label it with the `bug` label.',
-				'If it already has the product approval, please add the `product-approved` label.',
+				'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label',
 				'If none of the above applies, please consider removing the backport label and target the next major/minor release.',
 				'Thanks!',
 			].join('\n'),

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -237,7 +237,13 @@ const backport = async ({
 	sender,
 }: BackportArgs) => {
 	let labelsString = labels.map(({ name }) => name)
-	if (!(labelsString.includes('bug') || labelsString.includes('product-approved') || labelsString.includes('type/docs'))) {
+	if (
+		!(
+			labelsString.includes('bug') ||
+			labelsString.includes('product-approved') ||
+			labelsString.includes('type/docs')
+		)
+	) {
 		console.log(
 			'PR intended to be backported, but not labeled properly. Labels: ' +
 				labelsString +

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -20,11 +20,12 @@ const getLabelNames = ({
 	label: { name: string }
 	labels: EventPayloads.WebhookPayloadPullRequest['pull_request']['labels']
 }): string[] => {
+	let labelsString = labels.map(({ name }) => name)
 	switch (action) {
 		case 'closed':
 			return labels.map(({ name }) => name)
 		case 'labeled':
-			return [label.name]
+			return [label.name, ...labelsString]
 		default:
 			return []
 	}

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -239,7 +239,7 @@ const backport = async ({
 	let labelsString = labels.map(({ name }) => name)
 	if (
 		!(
-			labelsString.includes('bug') ||
+			labelsString.includes('type/bug') ||
 			labelsString.includes('product-approved') ||
 			labelsString.includes('type/docs')
 		)
@@ -257,7 +257,7 @@ const backport = async ({
 				'* Pull requests which address bugs,',
 				'* Urgent fixes which need product approval, in order to get merged,',
 				'* Docs changes.\n',
-				'Please, if the current pull request addresses a bug fix, label it with the `bug` label.',
+				'Please, if the current pull request addresses a bug fix, label it with the `type/bug` label.',
 				'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label',
 				'If none of the above applies, please consider removing the backport label and target the next major/minor release.',
 				'Thanks!',

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -258,7 +258,7 @@ const backport = async ({
 				'* Urgent fixes which need product approval, in order to get merged,',
 				'* Docs changes.\n',
 				'Please, if the current pull request addresses a bug fix, label it with the `type/bug` label.',
-				'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label',
+				'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label.',
 				'If none of the above applies, please consider removing the backport label and target the next major/minor release.',
 				'Thanks!',
 			].join('\n'),

--- a/backport/index.js
+++ b/backport/index.js
@@ -25,6 +25,7 @@ class Backport extends Action_1.Action {
                 titleTemplate: (0, core_1.getInput)('title'),
                 github: issue.octokit,
                 token: this.getToken(),
+                sender: github_1.context.payload.sender,
             });
         }
         catch (error) {

--- a/backport/index.ts
+++ b/backport/index.ts
@@ -24,6 +24,7 @@ class Backport extends Action {
 				titleTemplate: getInput('title'),
 				github: issue.octokit,
 				token: this.getToken(),
+				sender: context.payload.sender as EventPayloads.PayloadSender,
 			})
 		} catch (error) {
 			if (error instanceof Error) {


### PR DESCRIPTION
**Context**:

Backporting has always been a grey area for many engineers in Grafana Labs. It's not really clear how/what to backport when we are conducting a patch release. People tend to backport many changes, which leads to patch releases not really having the hard definition of the patch release. Patch releases should be bug fixes only and some changes that are critical and have the product/managers' approval. 

**What does this pull request do**:

This pull request, post a message to the PR, notifying the author of the PR (by '@username'), each time they backport and they don't have either the `bug` or `product-approved` labels. If none of these two labels are in place, the pull request cannot be backported. 

Related convo: https://raintank-corp.slack.com/archives/C03E2AQKU2W/p1669111455982429