### PR TITLE
Github Actions: Add `yarn-build` github action

### DIFF
--- a/.github/workflows/yarn-build.yml
+++ b/.github/workflows/yarn-build.yml
@@ -1,0 +1,37 @@
+name: yarn build
+
+on: pull_request
+
+jobs:
+  yarn-build:
+    name: yarn build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.16.0
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - name: Restore yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            yarn-cache-folder-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build yarn
+        run: yarn build
+
+      - name: Git checkout
+        uses: actions/checkout@v2
+        run: git diff --exit-code


### PR DESCRIPTION
Currently, there is no CI on this repo.
We add a new github action which checks if the `yarn build` command has ran.