### PR TITLE
Backporting: Fix buggy behaviour

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -155,7 +155,11 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
 const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     let labelsString = labels.map(({ name }) => name);
     let matchedLabels = getMatchedBackportLabels(labelsString, backportLabels);
-    if (matchedLabels.length == 0) {
+    let matches = false;
+    for (const label of labelsString) {
+        matches = labelRegExp.test(label);
+    }
+    if (matches && matchedLabels.length == 0) {
         console.log('PR intended to be backported, but not labeled properly. Labels: ' +
             labelsString +
             '\n Author: ' +

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -142,9 +142,14 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
 };
 const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     let labelsString = labels.map(({ name }) => name);
-    if (!(labelsString.includes('type/bug') ||
-        labelsString.includes('product-approved') ||
-        labelsString.includes('type/docs'))) {
+    let matches = false;
+    for (const label in labelsString) {
+        matches = labelRegExp.test(label);
+    }
+    if (matches &&
+        !(labelsString.includes('type/bug') ||
+            labelsString.includes('product-approved') ||
+            labelsString.includes('type/docs'))) {
         console.log('PR intended to be backported, but not labeled properly. Labels: ' +
             labelsString +
             '\n Author: ' +

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -26,8 +26,8 @@ const getLabelNames = ({ action, label, labels, }) => {
 };
 function getMatchedBackportLabels(labelsPR, backportLabels) {
     let matchedLabels = [];
-    for (const prLabel in labelsPR) {
-        for (const backportLabel in backportLabels) {
+    for (const prLabel of labelsPR) {
+        for (let backportLabel of backportLabels) {
             if (backportLabel === prLabel) {
                 matchedLabels.push(backportLabel);
             }

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -252,7 +252,11 @@ const backport = async ({
 }: BackportArgs) => {
 	let labelsString = labels.map(({ name }) => name)
 	let matchedLabels = getMatchedBackportLabels(labelsString, backportLabels)
-	if (matchedLabels.length == 0) {
+	let matches = false
+	for (const label of labelsString) {
+		matches = labelRegExp.test(label)
+	}
+	if (matches && matchedLabels.length == 0) {
 		console.log(
 			'PR intended to be backported, but not labeled properly. Labels: ' +
 				labelsString +

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -34,8 +34,8 @@ const getLabelNames = ({
 
 function getMatchedBackportLabels(labelsPR: string[], backportLabels: string[]): string[] {
 	let matchedLabels = []
-	for (const prLabel in labelsPR) {
-		for (const backportLabel in backportLabels) {
+	for (const prLabel of labelsPR) {
+		for (let backportLabel of backportLabels) {
 			if (backportLabel === prLabel) {
 				matchedLabels.push(backportLabel)
 			}

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -238,7 +238,12 @@ const backport = async ({
 	sender,
 }: BackportArgs) => {
 	let labelsString = labels.map(({ name }) => name)
+	let matches = false
+	for (const label in labelsString) {
+		matches = labelRegExp.test(label)
+	}
 	if (
+		matches &&
 		!(
 			labelsString.includes('type/bug') ||
 			labelsString.includes('product-approved') ||


### PR DESCRIPTION
This PR fixes some buggy behaviour that was introduced when https://github.com/grafana/grafana-github-actions/pull/113 was merged. 
Addresses: 
* Case when no label is added. We shouldn't get any notifications.
* `no-backport` shouldn't be a valid backport action label.