### PR TITLE
Backport: Break from loop if PR label matches regexp

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -158,6 +158,9 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
     let matches = false;
     for (const label of labelsString) {
         matches = labelRegExp.test(label);
+        if (matches) {
+            break;
+        }
     }
     if (matches && matchedLabels.length == 0) {
         console.log('PR intended to be backported, but not labeled properly. Labels: ' +

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -255,6 +255,9 @@ const backport = async ({
 	let matches = false
 	for (const label of labelsString) {
 		matches = labelRegExp.test(label)
+		if (matches) {
+			break
+		}
 	}
 	if (matches && matchedLabels.length == 0) {
 		console.log(


### PR DESCRIPTION
Bug fix based on https://github.com/grafana/grafana-github-actions/pull/115/files#r1031288511.

Thanks @dimitarvdimitrov 