### PR TITLE
Backport: Add `missing-labels` label

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -15,12 +15,11 @@ const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/;
 const backportLabels = ['type/docs', 'type/bug', 'product-approved'];
 const missingLabels = 'missing-labels';
 const getLabelNames = ({ action, label, labels, }) => {
-    let labelsString = labels.map(({ name }) => name);
     switch (action) {
         case 'closed':
             return labels.map(({ name }) => name);
         case 'labeled':
-            return [label.name, ...labelsString];
+            return [label.name];
         default:
             return [];
     }

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -13,6 +13,7 @@ const git_1 = require("../common/git");
 const BETTERER_RESULTS_PATH = '.betterer.results';
 const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/;
 const backportLabels = ['type/docs', 'type/bug', 'product-approved'];
+const missingLabels = 'missing-labels';
 const getLabelNames = ({ action, label, labels, }) => {
     let labelsString = labels.map(({ name }) => name);
     switch (action) {
@@ -162,7 +163,7 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
             break;
         }
     }
-    if (matches && matchedLabels.length == 0) {
+    if (matches && matchedLabels.length == 0 && !labelsString.includes(missingLabels)) {
         console.log('PR intended to be backported, but not labeled properly. Labels: ' +
             labelsString +
             '\n Author: ' +
@@ -180,6 +181,12 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                 'Thanks!',
             ].join('\n'),
             issue_number: pullRequestNumber,
+            owner,
+            repo,
+        });
+        await github.issues.addLabels({
+            issue_number: pullRequestNumber,
+            labels: [missingLabels],
             owner,
             repo,
         });

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -192,6 +192,14 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
         });
         return;
     }
+    else if (matches && matchedLabels.length != 0) {
+        await github.issues.removeLabel({
+            owner,
+            repo,
+            issue_number: pullRequestNumber,
+            name: missingLabels,
+        });
+    }
     if (!merged) {
         console.log('PR not merged');
         return;

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -7,6 +7,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.backport = void 0;
 const core_1 = require("@actions/core");
 const exec_1 = require("@actions/exec");
+const github_1 = require("@actions/github");
 const betterer_1 = require("@betterer/betterer");
 const lodash_escaperegexp_1 = __importDefault(require("lodash.escaperegexp"));
 const git_1 = require("../common/git");
@@ -153,6 +154,11 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
     ].join('\n');
 };
 const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
+    const payload = github_1.context.payload;
+    let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : '';
+    if (!labelRegExp.test(payloadLabel) || !backportLabels.includes(payloadLabel)) {
+        return;
+    }
     let labelsString = labels.map(({ name }) => name);
     let matchedLabels = getMatchedBackportLabels(labelsString, backportLabels);
     let matches = false;

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -191,7 +191,7 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
         });
         return;
     }
-    else if (matches && matchedLabels.length != 0) {
+    else if (matches && matchedLabels.length != 0 && labelsString.includes(missingLabels)) {
         await github.issues.removeLabel({
             owner,
             repo,

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -156,7 +156,7 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
 const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     const payload = github_1.context.payload;
     let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : '';
-    if (!labelRegExp.test(payloadLabel) || !backportLabels.includes(payloadLabel)) {
+    if (!(labelRegExp.test(payloadLabel) || backportLabels.includes(payloadLabel))) {
         return;
     }
     let labelsString = labels.map(({ name }) => name);

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -1,12 +1,12 @@
 // Based on code from https://github.com/tibdex/backport/blob/master/src/backport.ts
 
-import { error as logError, group, info } from '@actions/core'
-import { exec, getExecOutput } from '@actions/exec'
-import { GitHub } from '@actions/github'
-import { betterer } from '@betterer/betterer'
-import { EventPayloads } from '@octokit/webhooks'
+import {error as logError, group, info} from '@actions/core'
+import {exec, getExecOutput} from '@actions/exec'
+import {context, GitHub} from '@actions/github'
+import {betterer} from '@betterer/betterer'
+import {EventPayloads} from '@octokit/webhooks'
 import escapeRegExp from 'lodash.escaperegexp'
-import { cloneRepo } from '../common/git'
+import {cloneRepo} from '../common/git'
 
 const BETTERER_RESULTS_PATH = '.betterer.results'
 const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/
@@ -250,6 +250,11 @@ const backport = async ({
 	github,
 	sender,
 }: BackportArgs) => {
+	const payload = context.payload as EventPayloads.WebhookPayloadPullRequest
+	let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : ''
+	if (!labelRegExp.test(payloadLabel) || !backportLabels.includes(payloadLabel)) {
+		return
+	}
 	let labelsString = labels.map(({ name }) => name)
 	let matchedLabels = getMatchedBackportLabels(labelsString, backportLabels)
 	let matches = false

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -11,6 +11,7 @@ import { cloneRepo } from '../common/git'
 const BETTERER_RESULTS_PATH = '.betterer.results'
 const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/
 const backportLabels = ['type/docs', 'type/bug', 'product-approved']
+const missingLabels = 'missing-labels'
 
 const getLabelNames = ({
 	action,
@@ -259,7 +260,7 @@ const backport = async ({
 			break
 		}
 	}
-	if (matches && matchedLabels.length == 0) {
+	if (matches && matchedLabels.length == 0 && !labelsString.includes(missingLabels)) {
 		console.log(
 			'PR intended to be backported, but not labeled properly. Labels: ' +
 				labelsString +
@@ -279,6 +280,12 @@ const backport = async ({
 				'Thanks!',
 			].join('\n'),
 			issue_number: pullRequestNumber,
+			owner,
+			repo,
+		})
+		await github.issues.addLabels({
+			issue_number: pullRequestNumber,
+			labels: [missingLabels],
 			owner,
 			repo,
 		})

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -290,6 +290,13 @@ const backport = async ({
 			repo,
 		})
 		return
+	} else if (matches && matchedLabels.length != 0) {
+		await github.issues.removeLabel({
+			owner,
+			repo,
+			issue_number: pullRequestNumber,
+			name: missingLabels,
+		})
 	}
 
 	if (!merged) {

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -252,7 +252,7 @@ const backport = async ({
 }: BackportArgs) => {
 	const payload = context.payload as EventPayloads.WebhookPayloadPullRequest
 	let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : ''
-	if (!labelRegExp.test(payloadLabel) || !backportLabels.includes(payloadLabel)) {
+	if (!(labelRegExp.test(payloadLabel) || backportLabels.includes(payloadLabel))) {
 		return
 	}
 	let labelsString = labels.map(({ name }) => name)

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -22,12 +22,11 @@ const getLabelNames = ({
 	label: { name: string }
 	labels: EventPayloads.WebhookPayloadPullRequest['pull_request']['labels']
 }): string[] => {
-	let labelsString = labels.map(({ name }) => name)
 	switch (action) {
 		case 'closed':
 			return labels.map(({ name }) => name)
 		case 'labeled':
-			return [label.name, ...labelsString]
+			return [label.name]
 		default:
 			return []
 	}

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -289,7 +289,7 @@ const backport = async ({
 			repo,
 		})
 		return
-	} else if (matches && matchedLabels.length != 0) {
+	} else if (matches && matchedLabels.length != 0 && labelsString.includes(missingLabels)) {
 		await github.issues.removeLabel({
 			owner,
 			repo,


### PR DESCRIPTION
This PR adds a `missing-labels` label. This label will be automatically assigned to the pull request when there's a backport label assigned, but none of the mandatory labels `type/docs`, `type/bug`, `product-approved`.
This way we can make sure that we don't miss any backports during a release, and take immediate action.

Here's a spreadsheet with a manual case testing sequence: https://docs.google.com/spreadsheets/d/1lPxWXR01Tzlpm1Ia9ic4NEkqX8O1sXTlylF0ObJcf58/edit#gid=0 