### PR TITLE
Backport: Skip payload label if `action=closed`

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -155,6 +155,7 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
 };
 const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     const payload = github_1.context.payload;
+    console.log('payloadAction: ' + payload.action);
     if (payload.action !== 'closed') {
         let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : '';
         if (!(labelRegExp.test(payloadLabel) || backportLabels.includes(payloadLabel))) {

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -155,9 +155,11 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
 };
 const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     const payload = github_1.context.payload;
-    let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : '';
-    if (!(labelRegExp.test(payloadLabel) || backportLabels.includes(payloadLabel))) {
-        return;
+    if (payload.action !== 'closed') {
+        let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : '';
+        if (!(labelRegExp.test(payloadLabel) || backportLabels.includes(payloadLabel))) {
+            return;
+        }
     }
     let labelsString = labels.map(({ name }) => name);
     let matchedLabels = getMatchedBackportLabels(labelsString, backportLabels);

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -1,12 +1,12 @@
 // Based on code from https://github.com/tibdex/backport/blob/master/src/backport.ts
 
-import {error as logError, group, info} from '@actions/core'
-import {exec, getExecOutput} from '@actions/exec'
-import {context, GitHub} from '@actions/github'
-import {betterer} from '@betterer/betterer'
-import {EventPayloads} from '@octokit/webhooks'
+import { error as logError, group, info } from '@actions/core'
+import { exec, getExecOutput } from '@actions/exec'
+import { context, GitHub } from '@actions/github'
+import { betterer } from '@betterer/betterer'
+import { EventPayloads } from '@octokit/webhooks'
 import escapeRegExp from 'lodash.escaperegexp'
-import {cloneRepo} from '../common/git'
+import { cloneRepo } from '../common/git'
 
 const BETTERER_RESULTS_PATH = '.betterer.results'
 const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/
@@ -251,9 +251,11 @@ const backport = async ({
 	sender,
 }: BackportArgs) => {
 	const payload = context.payload as EventPayloads.WebhookPayloadPullRequest
-	let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : ''
-	if (!(labelRegExp.test(payloadLabel) || backportLabels.includes(payloadLabel))) {
-		return
+	if (payload.action !== 'closed') {
+		let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : ''
+		if (!(labelRegExp.test(payloadLabel) || backportLabels.includes(payloadLabel))) {
+			return
+		}
 	}
 	let labelsString = labels.map(({ name }) => name)
 	let matchedLabels = getMatchedBackportLabels(labelsString, backportLabels)

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -251,6 +251,7 @@ const backport = async ({
 	sender,
 }: BackportArgs) => {
 	const payload = context.payload as EventPayloads.WebhookPayloadPullRequest
+	console.log('payloadAction: ' + payload.action)
 	if (payload.action !== 'closed') {
 		let payloadLabel = typeof payload.label?.name === 'string' ? payload.label.name : ''
 		if (!(labelRegExp.test(payloadLabel) || backportLabels.includes(payloadLabel))) {


### PR DESCRIPTION
Right now, when a PR is closed it still looks for the payload for labels. If it doesn't find any, it returns.
This should only be true for `labeled` actions, and not for `closed`, since when we close a PR there are no labels in the payload.