### PR TITLE
Backport: Add console log for whether it's a merge action

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -208,13 +208,11 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
             name: missingLabels,
         });
     }
-    if (merged) {
-        console.log('This is a merge action');
-    }
-    else {
+    if (!merged) {
         console.log('PR not merged');
         return;
     }
+    console.log('This is a merge action');
     const backportBaseToHead = getBackportBaseToHead({
         action,
         // The payload has a label property when the action is "labeled".

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -208,7 +208,10 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
             name: missingLabels,
         });
     }
-    if (!merged) {
+    if (merged) {
+        console.log('This is a merge action');
+    }
+    else {
         console.log('PR not merged');
         return;
     }

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -306,12 +306,11 @@ const backport = async ({
 		})
 	}
 
-	if (merged) {
-		console.log('This is a merge action')
-	} else {
+	if (!merged) {
 		console.log('PR not merged')
 		return
 	}
+	console.log('This is a merge action')
 
 	const backportBaseToHead = getBackportBaseToHead({
 		action,

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -306,7 +306,9 @@ const backport = async ({
 		})
 	}
 
-	if (!merged) {
+	if (merged) {
+		console.log('This is a merge action')
+	} else {
 		console.log('PR not merged')
 		return
 	}


### PR DESCRIPTION
We've seen a couple of failures, where on a `merge` action (which is actually `closed` action, plus that the PR has been merged) it seems like gh action treats it as a simple PR close without merging. Some console log will help us understand what happens here.

My thoughts are that some fields in the payload webhooks were just missed due to GH blips 🤷 