### PR TITLE
Do not add milestone to backport PRs

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -47,7 +47,7 @@ const getBackportBaseToHead = ({ action, label, labels, pullRequestNumber, }) =>
     });
     return baseToHead;
 };
-const backportOnce = async ({ base, body, commitToBackport, github, head, labelsToAdd, owner, repo, title, milestone, mergedBy, }) => {
+const backportOnce = async ({ base, body, commitToBackport, github, head, labelsToAdd, owner, repo, title, mergedBy, }) => {
     const git = async (...args) => {
         await (0, exec_1.exec)('git', args, { cwd: repo });
     };
@@ -93,15 +93,6 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
         title,
     });
     const pullRequestNumber = createRsp.data.number;
-    // Sync milestone
-    if (milestone && milestone.id) {
-        await github.issues.update({
-            repo,
-            owner,
-            issue_number: pullRequestNumber,
-            milestone: milestone.number,
-        });
-    }
     // Remove default reviewers
     if (createRsp.data.requested_reviewers) {
         const reviewers = createRsp.data.requested_reviewers.map((user) => user.login);
@@ -153,7 +144,7 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
         `Then, create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
     ].join('\n');
 };
-const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
+const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     const payload = github_1.context.payload;
     console.log('payloadAction: ' + payload.action);
     if (payload.action !== 'closed') {
@@ -250,7 +241,6 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                     owner,
                     repo,
                     title,
-                    milestone,
                     mergedBy: merged_by,
                 });
             }

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -79,7 +79,6 @@ const backportOnce = async ({
 	owner,
 	repo,
 	title,
-	milestone,
 	mergedBy,
 }: {
 	base: string
@@ -91,7 +90,6 @@ const backportOnce = async ({
 	owner: string
 	repo: string
 	title: string
-	milestone: EventPayloads.WebhookPayloadPullRequestPullRequestMilestone
 	mergedBy: any
 }) => {
 	const git = async (...args: string[]) => {
@@ -141,16 +139,6 @@ const backportOnce = async ({
 	})
 
 	const pullRequestNumber = createRsp.data.number
-
-	// Sync milestone
-	if (milestone && milestone.id) {
-		await github.issues.update({
-			repo,
-			owner,
-			issue_number: pullRequestNumber,
-			milestone: milestone.number,
-		})
-	}
 
 	// Remove default reviewers
 	if (createRsp.data.requested_reviewers) {
@@ -237,7 +225,6 @@ const backport = async ({
 			merged,
 			number: pullRequestNumber,
 			title: originalTitle,
-			milestone,
 			merged_by,
 		},
 		repository: {
@@ -356,7 +343,6 @@ const backport = async ({
 					owner,
 					repo,
 					title,
-					milestone,
 					mergedBy: merged_by,
 				})
 			} catch (error) {


### PR DESCRIPTION
The milestone is decided by the original PR and often does not match the required milestone for a backport PR to produce a correct changelog entry.

By not automatically setting the milestone, maintainers are required to consider and set it themselves. I currently believed that edge cases around target branch to milestone mapping (such as out of date milestones) mean that this human step is less error prone than code would be.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>