### PR TITLE
Issues: Add action that makes org members add a label

### DIFF
--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -53,6 +53,14 @@ class Commands {
             return (0, globmatcher_1.checkMatch)(changedFiles, matchCfg);
         }
         if (command.type === 'author') {
+            const labelPropExists = command.noLabels;
+            const issueHasLabel = issue.labels.length > 0;
+            if (labelPropExists && issueHasLabel) {
+                return 'noLabels' in command ? false : true;
+            }
+            if (labelPropExists && !issueHasLabel && command.comment) {
+                command.comment = '@' + issue.author.name + command.comment;
+            }
             const org = command.memberOf?.org || command.notMemberOf?.org;
             if (command.ignoreList?.length && command.ignoreList.includes(issue.author.name)) {
                 return false;

--- a/commands/Commands.test.ts
+++ b/commands/Commands.test.ts
@@ -454,6 +454,39 @@ describe('Commands', () => {
 			expect(comments[0].body).to.equal('@JacksonKearl please add a label')
 		})
 
+		it('Does not add label or comment when author is NOT member of org and creates issue with no labels', async () => {
+			const testbed = new TestbedIssue(
+				{
+					writers: ['JacksonKearl'],
+					userMemberOfOrganization: false,
+				},
+				{
+					labels: [],
+				},
+			)
+			const commands: Command[] = [
+				{
+					type: 'author',
+					name: 'Grafana author',
+					memberOf: { org: 'grafana' },
+					noLabels: true,
+					addLabel: 'internal',
+					comment: ' please add a label',
+				},
+			]
+
+			expect(((await testbed.getIssue()).labels.length = 0))
+
+			await new Commands(testbed, commands, {}).run()
+
+			expect(((await testbed.getIssue()).labels.length = 0))
+			const comments = []
+			for await (const page of testbed.getComments()) {
+				comments.push(...page)
+			}
+			expect(comments.length).to.equal(0)
+		})
+
 		it('Labels not when author is member of organization', async () => {
 			const testbed = new TestbedIssue(
 				{

--- a/commands/Commands.test.ts
+++ b/commands/Commands.test.ts
@@ -420,6 +420,40 @@ describe('Commands', () => {
 			expect((await testbed.getIssue()).labels).to.contain('new')
 		})
 
+		it('Labels and comments when author is member of org and adds no labels', async () => {
+			const testbed = new TestbedIssue(
+				{
+					writers: ['JacksonKearl'],
+					userMemberOfOrganization: true,
+				},
+				{
+					labels: [],
+				},
+			)
+			const commands: Command[] = [
+				{
+					type: 'author',
+					name: 'Grafana author',
+					memberOf: { org: 'grafana' },
+					noLabels: true,
+					addLabel: 'internal',
+					comment: ' please add a label',
+				},
+			]
+
+			expect(((await testbed.getIssue()).labels.length = 0))
+
+			await new Commands(testbed, commands, {}).run()
+
+			expect(((await testbed.getIssue()).labels.length = 1))
+			expect((await testbed.getIssue()).labels).to.contain('internal')
+			const comments = []
+			for await (const page of testbed.getComments()) {
+				comments.push(...page)
+			}
+			expect(comments[0].body).to.equal('@JacksonKearl please add a label')
+		})
+
 		it('Labels not when author is member of organization', async () => {
 			const testbed = new TestbedIssue(
 				{

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -82,7 +82,7 @@ export class Commands {
 			if (labelPropExists && !issueHasLabel && command.comment) {
 				command.comment = '@' + issue.author.name + command.comment
 			}
-			
+
 			const org = command.memberOf?.org || command.notMemberOf?.org
 
 			if (command.ignoreList?.length && command.ignoreList.includes(issue.author.name)) {


### PR DESCRIPTION
This new action will work in conjunction [with this modified workflow](https://github.com/grafana/grafana/pull/63158) in the grafana/grafana repo.

It will check when an issue is opened, if it was opened by a grafanista, and if any labels were added.

If a Grafanista makes an issue but adds no label, the `internal` label will be added and they will be pinged in a comment like this:

![CleanShot 2023-02-08 at 12 58 31@2x](https://user-images.githubusercontent.com/37156449/217670626-ed8dfeb1-3709-4be8-bb95-91f721d1900b.png)

You can test drive the new action in my private repo. [Make an issue here](https://github.com/zuchka/grafana-action-test/issues/new?assignees=&labels=type%3A+bug&template=1-bug_report.md) but DON'T add any labels. If you are a member of the Grafana org, you'll see a label and a comment added

**why do we need this?**
Lots of internal folks use issues as todos or reminders for themselves but don't add labels. Lots of other internal folks make issues for other teams but don't add labels. This allows the triage team to filter out these personal issues, and to get internally created issues to the proper team faster. Both of these scenarios will help reduce the number of issues we have to triage.