### PR TITLE
Match any reasonable patch version

### DIFF
--- a/has-matching-release-tag/hasMatchingReleaseTag.js
+++ b/has-matching-release-tag/hasMatchingReleaseTag.js
@@ -39,7 +39,7 @@ function hasMatchingReleaseTagWithRefNames(refNames, refName, releaseTagRegexp, 
             if (tagMatches &&
                 tagMatches[1] == branchMatches[1] &&
                 tagMatches[2] == branchMatches[2] &&
-                tagMatches[3] == '0') {
+                tagMatches[3].match(new RegExp('0|[1-9]d*'))) {
                 console.log(`Found corresponding release tag for branch '${refName}': '${releaseTags[i]}'`);
                 return 'true';
             }

--- a/has-matching-release-tag/hasMatchingReleaseTag.test.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.test.ts
@@ -69,4 +69,27 @@ test('hasMatchingReleaseTagWithRefNames', () => {
 			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
 		),
 	).toBe('false')
+
+	// Missing the `.0` patch version.
+	// Although semver requires that every bump of a major or minor version resets the patch version,
+	// it is not always the case that the tag will exist in the repository.
+	// For example, the first release might be made privately in a fork and might never be made public
+	// because of bugs or security concerns.
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			['v1.0.1'],
+			'release-1.0',
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+		),
+	).toBe('true')
+	// Don't allow release candidates to be considered "proper" releases.
+	expect(
+		hasMatchingReleaseTagWithRefNames(
+			['v1.0.1-rc.1'],
+			'release-1.0',
+			new RegExp('^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+			new RegExp('^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$'),
+		),
+	).toBe('false')
 })

--- a/has-matching-release-tag/hasMatchingReleaseTag.ts
+++ b/has-matching-release-tag/hasMatchingReleaseTag.ts
@@ -57,7 +57,7 @@ export function hasMatchingReleaseTagWithRefNames(
 				tagMatches &&
 				tagMatches[1] == branchMatches[1] &&
 				tagMatches[2] == branchMatches[2] &&
-				tagMatches[3] == '0'
+				tagMatches[3].match(new RegExp('0|[1-9]d*'))
 			) {
 				console.log(`Found corresponding release tag for branch '${refName}': '${releaseTags[i]}'`)
 				return 'true'


### PR DESCRIPTION
Although semver requires that every bump of a major or minor version resets the patch version, it is not always the case that the tag will exist in the repository. For example, the first release might be made privately in a fork and might never be made public because of bugs or security concerns.