### PR TITLE
Add release notes appender action

### DIFF
--- a/common/telemetry.js
+++ b/common/telemetry.js
@@ -56,7 +56,7 @@ if (apiKey) {
 }
 function getMetricsNamePrefix() {
     if (!github_1.context || github_1.context.repo.repo === 'grafana') {
-        // this is for grafana repo, did not make this multi repo at the start and do not want to loose past metrics
+        // this is for grafana repo, did not make this multi repo at the start and do not want to lose past metrics
         return 'gh_action';
     }
     return `repo_stats.${github_1.context.repo.repo}`;

--- a/common/telemetry.ts
+++ b/common/telemetry.ts
@@ -71,7 +71,7 @@ if (apiKey) {
 
 function getMetricsNamePrefix() {
 	if (!context || context.repo.repo === 'grafana') {
-		// this is for grafana repo, did not make this multi repo at the start and do not want to loose past metrics
+		// this is for grafana repo, did not make this multi repo at the start and do not want to lose past metrics
 		return 'gh_action'
 	}
 	return `repo_stats.${context.repo.repo}`

--- a/release-notes-appender/FileAppender.js
+++ b/release-notes-appender/FileAppender.js
@@ -5,12 +5,16 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.FileAppender = void 0;
 const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
 const utils_1 = require("../common/utils");
 class FileAppender {
-    constructor() {
+    constructor(opts = {}) {
         this.lines = [];
+        this.options = {};
+        this.options = opts;
     }
-    loadFile(filePath) {
+    loadFile(relPath) {
+        let filePath = this.options.cwd ? path_1.default.resolve(this.options.cwd, relPath) : relPath;
         if (!fs_1.default.existsSync(filePath)) {
             throw new Error(`File not found ${filePath}`);
         }
@@ -20,7 +24,8 @@ class FileAppender {
     append(content) {
         this.lines.push(content);
     }
-    writeFile(filePath) {
+    writeFile(relPath) {
+        let filePath = this.options.cwd ? path_1.default.resolve(this.options.cwd, relPath) : relPath;
         fs_1.default.writeFileSync(filePath, this.getContent(), { encoding: 'utf-8' });
     }
     getContent() {

--- a/release-notes-appender/FileAppender.js
+++ b/release-notes-appender/FileAppender.js
@@ -1,0 +1,31 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.FileAppender = void 0;
+const fs_1 = __importDefault(require("fs"));
+const utils_1 = require("../common/utils");
+class FileAppender {
+    constructor() {
+        this.lines = [];
+    }
+    loadFile(filePath) {
+        if (!fs_1.default.existsSync(filePath)) {
+            throw new Error(`File not found ${filePath}`);
+        }
+        const fileContent = fs_1.default.readFileSync(filePath, 'utf-8');
+        this.lines = (0, utils_1.splitStringIntoLines)(fileContent);
+    }
+    append(content) {
+        this.lines.push(content);
+    }
+    writeFile(filePath) {
+        fs_1.default.writeFileSync(filePath, this.getContent(), { encoding: 'utf-8' });
+    }
+    getContent() {
+        return this.lines.join('\r\n');
+    }
+}
+exports.FileAppender = FileAppender;
+//# sourceMappingURL=FileAppender.js.map

--- a/release-notes-appender/FileAppender.ts
+++ b/release-notes-appender/FileAppender.ts
@@ -1,10 +1,21 @@
 import fs from 'fs'
+import path from 'path'
 import { splitStringIntoLines } from '../common/utils'
+
+interface FileAppenderOptions {
+	cwd?: string
+}
 
 export class FileAppender {
 	private lines: string[] = []
+	private options: FileAppenderOptions = {}
 
-	loadFile(filePath: string) {
+	constructor(opts: FileAppenderOptions = {}) {
+		this.options = opts
+	}
+
+	loadFile(relPath: string) {
+		let filePath = this.options.cwd ? path.resolve(this.options.cwd, relPath) : relPath
 		if (!fs.existsSync(filePath)) {
 			throw new Error(`File not found ${filePath}`)
 		}
@@ -17,7 +28,8 @@ export class FileAppender {
 		this.lines.push(content)
 	}
 
-	writeFile(filePath: string) {
+	writeFile(relPath: string) {
+		let filePath = this.options.cwd ? path.resolve(this.options.cwd, relPath) : relPath
 		fs.writeFileSync(filePath, this.getContent(), { encoding: 'utf-8' })
 	}
 

--- a/release-notes-appender/FileAppender.ts
+++ b/release-notes-appender/FileAppender.ts
@@ -1,0 +1,27 @@
+import fs from 'fs'
+import { splitStringIntoLines } from '../common/utils'
+
+export class FileAppender {
+	private lines: string[] = []
+
+	loadFile(filePath: string) {
+		if (!fs.existsSync(filePath)) {
+			throw new Error(`File not found ${filePath}`)
+		}
+
+		const fileContent = fs.readFileSync(filePath, 'utf-8')
+		this.lines = splitStringIntoLines(fileContent)
+	}
+
+	append(content: string) {
+		this.lines.push(content)
+	}
+
+	writeFile(filePath: string) {
+		fs.writeFileSync(filePath, this.getContent(), { encoding: 'utf-8' })
+	}
+
+	public getContent() {
+		return this.lines.join('\r\n')
+	}
+}

--- a/release-notes-appender/action.yml
+++ b/release-notes-appender/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: Comma separated list of labels to add to the release notes PR.
     required: false
   metricsWriteAPIKey:
-    description: Grfana Cloud metrics api key
+    description: Grafana Cloud metrics api key
     required: false
 runs:
   using: 'node16'

--- a/release-notes-appender/action.yml
+++ b/release-notes-appender/action.yml
@@ -1,0 +1,22 @@
+---
+name: Release Notes Appender
+description: Automatically appende a PR to the next release's release notes
+inputs:
+  token:
+    description: GitHub token with issue, comment, and label read/write permissions
+    default: ${{ github.token }}
+  title:
+    description: Title for the backport PR
+    default: "[Release Notes {{base}}] Add {{originalTitle}}"
+  releaseNotesFile:
+    description: Path to the files to append to
+    required: true
+  labelsToAdd:
+    description: Comma separated list of labels to add to the release notes PR.
+    required: false
+  metricsWriteAPIKey:
+    description: Grfanaa Cloud metrics api key
+    required: false
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/release-notes-appender/action.yml
+++ b/release-notes-appender/action.yml
@@ -1,12 +1,12 @@
 ---
 name: Release Notes Appender
-description: Automatically appende a PR to the next release's release notes
+description: Automatically append a PR to the next release's release notes
 inputs:
   token:
     description: GitHub token with issue, comment, and label read/write permissions
     default: ${{ github.token }}
   title:
-    description: Title for the backport PR
+    description: Title for the PR to be created
     default: "[Release Notes Appender] Add PR #{{pullRequestNumber}}: {{originalTitle}}"
   releaseNotesFile:
     description: Path to the files to append to
@@ -15,7 +15,7 @@ inputs:
     description: Comma separated list of labels to add to the release notes PR.
     required: false
   metricsWriteAPIKey:
-    description: Grfanaa Cloud metrics api key
+    description: Grfana Cloud metrics api key
     required: false
 runs:
   using: 'node16'

--- a/release-notes-appender/action.yml
+++ b/release-notes-appender/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: ${{ github.token }}
   title:
     description: Title for the backport PR
-    default: "[Release Notes {{base}}] Add {{originalTitle}}"
+    default: "[Release Notes Appender] Add PR #{{pullRequestNumber}}: {{originalTitle}}"
   releaseNotesFile:
     description: Path to the files to append to
     required: true

--- a/release-notes-appender/index.js
+++ b/release-notes-appender/index.js
@@ -1,0 +1,49 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getLabelsToAdd = void 0;
+const core_1 = require("@actions/core");
+const github_1 = require("@actions/github");
+const Action_1 = require("../common/Action");
+const release_1 = require("./release");
+class ReleaseNotesAppender extends Action_1.Action {
+    constructor() {
+        super(...arguments);
+        this.id = 'ReleaseNotesAppender';
+    }
+    async onClosed(issue) {
+        return this.release(issue);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async onLabeled(issue, _label) {
+        return this.release(issue);
+    }
+    async release(issue) {
+        try {
+            await (0, release_1.release)({
+                labelsToAdd: (0, exports.getLabelsToAdd)((0, core_1.getInput)('labelsToAdd')),
+                payload: github_1.context.payload,
+                titleTemplate: (0, core_1.getInput)('title'),
+                releaseNotesFile: (0, core_1.getInput)('releaseNotesFile'),
+                github: issue.octokit,
+                token: this.getToken(),
+                sender: github_1.context.payload.sender,
+            });
+        }
+        catch (error) {
+            if (error instanceof Error) {
+                (0, core_1.error)(error);
+                (0, core_1.setFailed)(error.message);
+            }
+        }
+    }
+}
+const getLabelsToAdd = (input) => {
+    if (input === undefined || input === '') {
+        return [];
+    }
+    const labels = input.split(',');
+    return labels.map((v) => v.trim()).filter((v) => v !== '');
+};
+exports.getLabelsToAdd = getLabelsToAdd;
+new ReleaseNotesAppender().run(); // eslint-disable-line
+//# sourceMappingURL=index.js.map

--- a/release-notes-appender/index.ts
+++ b/release-notes-appender/index.ts
@@ -1,0 +1,48 @@
+import { error as logError, getInput, setFailed } from '@actions/core'
+import { context } from '@actions/github'
+import { EventPayloads } from '@octokit/webhooks'
+import { OctoKitIssue } from '../api/octokit'
+import { Action } from '../common/Action'
+import { release } from './release'
+
+class ReleaseNotesAppender extends Action {
+	id = 'ReleaseNotesAppender'
+
+	async onClosed(issue: OctoKitIssue) {
+		return this.release(issue)
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async onLabeled(issue: OctoKitIssue, _label: string) {
+		return this.release(issue)
+	}
+
+	async release(issue: OctoKitIssue) {
+		try {
+			await release({
+				labelsToAdd: getLabelsToAdd(getInput('labelsToAdd')),
+				payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
+				titleTemplate: getInput('title'),
+				releaseNotesFile: getInput('releaseNotesFile'),
+				github: issue.octokit,
+				token: this.getToken(),
+				sender: context.payload.sender as EventPayloads.PayloadSender,
+			})
+		} catch (error) {
+			if (error instanceof Error) {
+				logError(error)
+				setFailed(error.message)
+			}
+		}
+	}
+}
+
+export const getLabelsToAdd = (input: string | undefined): string[] => {
+	if (input === undefined || input === '') {
+		return []
+	}
+
+	const labels = input.split(',')
+	return labels.map((v) => v.trim()).filter((v) => v !== '')
+}
+
+new ReleaseNotesAppender().run() // eslint-disable-line

--- a/release-notes-appender/release.js
+++ b/release-notes-appender/release.js
@@ -98,7 +98,6 @@ const getFailedPRCommentBody = ({ prNumber, prUrl, prTitle, releaseNotesFile, er
     ].join('\n');
 };
 const release = async ({ labelsToAdd, payload: { pull_request: { labels, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, releaseNotesFile, token, github, }) => {
-    //TODO create interface type for arguments
     const payload = github_1.context.payload;
     console.log('payloadAction: ' + payload.action);
     let labelsString = labels.map(({ name }) => name);
@@ -115,7 +114,7 @@ const release = async ({ labelsToAdd, payload: { pull_request: { labels, merged,
     }
     if (!merged) {
         console.log('PR not merged');
-        // 	return
+        return;
     }
     console.log('This is a merge action');
     await (0, git_1.cloneRepo)({ token, owner, repo });

--- a/release-notes-appender/release.js
+++ b/release-notes-appender/release.js
@@ -1,32 +1,29 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.release = void 0;
 const core_1 = require("@actions/core");
 const github_1 = require("@actions/github");
 const git_1 = require("../common/git");
 const exec_1 = require("@actions/exec");
-const lodash_escaperegexp_1 = __importDefault(require("lodash.escaperegexp"));
 const FileAppender_1 = require("./FileAppender");
-const labelRegExp = /release notes ([^ ]+)(?: ([^ ]+))?$/;
-const createReleaseNotesPR = async ({ base, prNumber, prUrl, prTitle, releaseNotesFile, github, head, labelsToAdd, owner, repo, title, milestone, mergedBy, }) => {
+const labelMatcher = 'add-to-release-notes';
+const createReleaseNotesPR = async ({ prNumber, prUrl, prTitle, releaseNotesFile, github, head, labelsToAdd, owner, repo, title, milestone, mergedBy, }) => {
     const git = async (...args) => {
         await (0, exec_1.exec)('git', args, { cwd: repo });
     };
-    await git('switch', base);
+    await git('checkout', 'main');
+    await git('pull');
     await git('switch', '--create', head);
     const fileAppender = new FileAppender_1.FileAppender();
     fileAppender.loadFile(releaseNotesFile);
     fileAppender.append('* [PR #' + prNumber + '](' + prUrl + ') - ' + prTitle);
     fileAppender.writeFile(releaseNotesFile);
     await git('add', releaseNotesFile);
-    const body = 'Add PR #' + prNumber + ' to release notes for release ' + base;
+    const body = 'Add PR #' + prNumber + ' to release notes for next release';
     await git('commit', '-m', body);
     await git('push', '--set-upstream', 'origin', head);
     const createRsp = await github.pulls.create({
-        base,
+        base: 'main',
         body,
         head,
         owner,
@@ -71,129 +68,98 @@ const createReleaseNotesPR = async ({ base, prNumber, prUrl, prTitle, releaseNot
         });
     }
 };
-const getLabelNames = ({ action, label, labels, }) => {
-    switch (action) {
-        case 'closed':
-            return labels.map(({ name }) => name);
-        case 'labeled':
-            return [label.name];
-        default:
-            return [];
-    }
-};
-const getBackportBaseToHead = ({ action, label, labels, pullRequestNumber, }) => {
-    const baseToHead = {};
-    getLabelNames({ action, label, labels }).forEach((labelName) => {
-        const matches = labelRegExp.exec(labelName);
-        if (matches !== null) {
-            const [, base, head = `add-${pullRequestNumber}-to-release-notes-${base}`] = matches;
-            baseToHead[base] = head;
-        }
-    });
-    return baseToHead;
-};
-const getFailedPRCommentBody = ({ base, errorMessage, head, }) => {
+const getFailedPRCommentBody = ({ prNumber, prUrl, prTitle, releaseNotesFile, errorMessage, head, }) => {
     return [
-        `The backport to \`${base}\` failed:`,
+        `Faile to add PR #${prNumber} to the release notes`,
         '```',
         errorMessage,
         '```',
-        'To create PR manually, run these commands in your terminal:',
+        'To create this PR manually, run these commands in your terminal:',
         '```bash',
         '# Fetch latest updates from GitHub',
         'git fetch',
         '# Create a new branch',
-        `git switch --create ${head} origin/${base}`,
+        `git switch --create ${head} origin/main`,
         '# Add the relevant PR to the release notes',
-        '# TODO: include commands for adding PR to release notes',
+        `echo "* [PR #${prNumber}](${prUrl}) - ${prTitle}" >> ${releaseNotesFile}`,
+        `git add ${releaseNotesFile}`,
+        `git commit -m "Add PR #${prNumber} to release notes for next release`,
         '# Push it to GitHub',
         `git push --set-upstream origin ${head}`,
         `git switch main`,
         '# Remove the local branch',
         `git branch -D ${head}`,
         '```',
-        `Then, create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
+        `Then, create a pull request where the \`base\` branch is \`origin/main\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
     ].join('\n');
 };
-const release = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, releaseNotesFile, token, github, }) => {
+const release = async ({ labelsToAdd, payload: { pull_request: { labels, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, releaseNotesFile, token, github, }) => {
     //TODO create interface type for arguments
     const payload = github_1.context.payload;
     console.log('payloadAction: ' + payload.action);
     let labelsString = labels.map(({ name }) => name);
     let matches = false;
     for (const label of labelsString) {
-        matches = labelRegExp.test(label);
+        matches = labelMatcher === label;
         if (matches) {
             break;
         }
     }
+    if (!matches) {
+        console.log("PR doesn't contain label " + labelMatcher + '. Not adding to release notes.');
+        return;
+    }
     if (!merged) {
         console.log('PR not merged');
-        return;
+        // 	return
     }
     console.log('This is a merge action');
-    //TODO: Note that base here is the release version, not any sort of branch
-    const backportBaseToHead = getBackportBaseToHead({
-        action,
-        // The payload has a label property when the action is "labeled".
-        label: label,
-        labels,
-        pullRequestNumber,
-    });
-    if (Object.keys(backportBaseToHead).length === 0) {
-        return;
-    }
     await (0, git_1.cloneRepo)({ token, owner, repo });
-    for (const [base, head] of Object.entries(backportBaseToHead)) {
-        let title = titleTemplate;
-        Object.entries({
-            base,
-            originalTitle,
-        }).forEach(([name, value]) => {
-            title = title.replace(new RegExp((0, lodash_escaperegexp_1.default)(`{{${name}}}`), 'g'), value);
-        });
-        await (0, core_1.group)(`Creating PR for ${head} to ${base}`, async () => {
-            try {
-                await createReleaseNotesPR({
-                    base,
+    let title = titleTemplate;
+    let head = `add-${pullRequestNumber}-to-release-notes`;
+    await (0, core_1.group)(`Adding ${pullRequestNumber} to release notes for next release`, async () => {
+        try {
+            await createReleaseNotesPR({
+                prNumber: pullRequestNumber,
+                prTitle: originalTitle,
+                prUrl: payload.pull_request.html_url,
+                releaseNotesFile,
+                github: github,
+                head,
+                labelsToAdd,
+                owner,
+                repo,
+                title,
+                milestone,
+                mergedBy: merged_by,
+            });
+        }
+        catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error while backporting';
+            (0, core_1.error)(errorMessage);
+            // Create comment
+            await github.issues.createComment({
+                body: getFailedPRCommentBody({
                     prNumber: pullRequestNumber,
-                    prTitle: originalTitle,
                     prUrl: payload.pull_request.html_url,
+                    prTitle: originalTitle,
                     releaseNotesFile,
-                    github: github,
+                    errorMessage,
                     head,
-                    labelsToAdd,
-                    owner,
-                    repo,
-                    title,
-                    milestone,
-                    mergedBy: merged_by,
-                });
-            }
-            catch (error) {
-                const errorMessage = error instanceof Error ? error.message : 'Unknown error while backporting';
-                (0, core_1.error)(errorMessage);
-                // Create comment
-                await github.issues.createComment({
-                    body: getFailedPRCommentBody({
-                        base,
-                        errorMessage,
-                        head,
-                    }),
-                    issue_number: pullRequestNumber,
-                    owner,
-                    repo,
-                });
-                // Add release-notes-failed label to failures
-                await github.issues.addLabels({
-                    issue_number: pullRequestNumber,
-                    labels: ['release-notes-failed'],
-                    owner,
-                    repo,
-                });
-            }
-        });
-    }
+                }),
+                issue_number: pullRequestNumber,
+                owner,
+                repo,
+            });
+            // Add release-notes-failed label to failures
+            await github.issues.addLabels({
+                issue_number: pullRequestNumber,
+                labels: ['release-notes-failed'],
+                owner,
+                repo,
+            });
+        }
+    });
 };
 exports.release = release;
 //# sourceMappingURL=release.js.map

--- a/release-notes-appender/release.js
+++ b/release-notes-appender/release.js
@@ -74,7 +74,7 @@ const createReleaseNotesPR = async ({ pullRequestNumber: prNumber, pullRequestUr
 };
 const getFailedPRCommentBody = ({ prNumber, prUrl, prTitle, releaseNotesFile, errorMessage, head, }) => {
     return [
-        `Faile to add PR #${prNumber} to the release notes`,
+        `Failed to add PR #${prNumber} to the release notes`,
         '```',
         errorMessage,
         '```',

--- a/release-notes-appender/release.js
+++ b/release-notes-appender/release.js
@@ -14,7 +14,7 @@ const createReleaseNotesPR = async ({ prNumber, prUrl, prTitle, releaseNotesFile
     await git('checkout', 'main');
     await git('pull');
     await git('switch', '--create', head);
-    const fileAppender = new FileAppender_1.FileAppender();
+    const fileAppender = new FileAppender_1.FileAppender({ cwd: repo });
     fileAppender.loadFile(releaseNotesFile);
     fileAppender.append('* [PR #' + prNumber + '](' + prUrl + ') - ' + prTitle);
     fileAppender.writeFile(releaseNotesFile);

--- a/release-notes-appender/release.js
+++ b/release-notes-appender/release.js
@@ -1,0 +1,199 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.release = void 0;
+const core_1 = require("@actions/core");
+const github_1 = require("@actions/github");
+const git_1 = require("../common/git");
+const exec_1 = require("@actions/exec");
+const lodash_escaperegexp_1 = __importDefault(require("lodash.escaperegexp"));
+const FileAppender_1 = require("./FileAppender");
+const labelRegExp = /release notes ([^ ]+)(?: ([^ ]+))?$/;
+const createReleaseNotesPR = async ({ base, prNumber, prUrl, prTitle, releaseNotesFile, github, head, labelsToAdd, owner, repo, title, milestone, mergedBy, }) => {
+    const git = async (...args) => {
+        await (0, exec_1.exec)('git', args, { cwd: repo });
+    };
+    await git('switch', base);
+    await git('switch', '--create', head);
+    const fileAppender = new FileAppender_1.FileAppender();
+    fileAppender.loadFile(releaseNotesFile);
+    fileAppender.append('* [PR #' + prNumber + '](' + prUrl + ') - ' + prTitle);
+    fileAppender.writeFile(releaseNotesFile);
+    await git('add', releaseNotesFile);
+    const body = 'Add PR #' + prNumber + ' to release notes for release ' + base;
+    await git('commit', '-m', body);
+    await git('push', '--set-upstream', 'origin', head);
+    const createRsp = await github.pulls.create({
+        base,
+        body,
+        head,
+        owner,
+        repo,
+        title,
+    });
+    const pullRequestNumber = createRsp.data.number;
+    // Sync milestone
+    if (milestone && milestone.id) {
+        await github.issues.update({
+            repo,
+            owner,
+            issue_number: pullRequestNumber,
+            milestone: milestone.number,
+        });
+    }
+    // Remove default reviewers
+    if (createRsp.data.requested_reviewers) {
+        const reviewers = createRsp.data.requested_reviewers.map((user) => user.login);
+        await github.pulls.deleteReviewRequest({
+            pull_number: pullRequestNumber,
+            repo,
+            owner,
+            reviewers: reviewers,
+        });
+    }
+    if (mergedBy) {
+        // Assign to merger
+        await github.pulls.createReviewRequest({
+            pull_number: pullRequestNumber,
+            repo,
+            owner,
+            reviewers: [mergedBy.login],
+        });
+    }
+    if (labelsToAdd.length > 0) {
+        await github.issues.addLabels({
+            issue_number: pullRequestNumber,
+            labels: labelsToAdd,
+            owner,
+            repo,
+        });
+    }
+};
+const getLabelNames = ({ action, label, labels, }) => {
+    switch (action) {
+        case 'closed':
+            return labels.map(({ name }) => name);
+        case 'labeled':
+            return [label.name];
+        default:
+            return [];
+    }
+};
+const getBackportBaseToHead = ({ action, label, labels, pullRequestNumber, }) => {
+    const baseToHead = {};
+    getLabelNames({ action, label, labels }).forEach((labelName) => {
+        const matches = labelRegExp.exec(labelName);
+        if (matches !== null) {
+            const [, base, head = `add-${pullRequestNumber}-to-release-notes-${base}`] = matches;
+            baseToHead[base] = head;
+        }
+    });
+    return baseToHead;
+};
+const getFailedPRCommentBody = ({ base, errorMessage, head, }) => {
+    return [
+        `The backport to \`${base}\` failed:`,
+        '```',
+        errorMessage,
+        '```',
+        'To create PR manually, run these commands in your terminal:',
+        '```bash',
+        '# Fetch latest updates from GitHub',
+        'git fetch',
+        '# Create a new branch',
+        `git switch --create ${head} origin/${base}`,
+        '# Add the relevant PR to the release notes',
+        '# TODO: include commands for adding PR to release notes',
+        '# Push it to GitHub',
+        `git push --set-upstream origin ${head}`,
+        `git switch main`,
+        '# Remove the local branch',
+        `git branch -D ${head}`,
+        '```',
+        `Then, create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
+    ].join('\n');
+};
+const release = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merged, number: pullRequestNumber, title: originalTitle, milestone, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, releaseNotesFile, token, github, }) => {
+    //TODO create interface type for arguments
+    const payload = github_1.context.payload;
+    console.log('payloadAction: ' + payload.action);
+    let labelsString = labels.map(({ name }) => name);
+    let matches = false;
+    for (const label of labelsString) {
+        matches = labelRegExp.test(label);
+        if (matches) {
+            break;
+        }
+    }
+    if (!merged) {
+        console.log('PR not merged');
+        return;
+    }
+    console.log('This is a merge action');
+    //TODO: Note that base here is the release version, not any sort of branch
+    const backportBaseToHead = getBackportBaseToHead({
+        action,
+        // The payload has a label property when the action is "labeled".
+        label: label,
+        labels,
+        pullRequestNumber,
+    });
+    if (Object.keys(backportBaseToHead).length === 0) {
+        return;
+    }
+    await (0, git_1.cloneRepo)({ token, owner, repo });
+    for (const [base, head] of Object.entries(backportBaseToHead)) {
+        let title = titleTemplate;
+        Object.entries({
+            base,
+            originalTitle,
+        }).forEach(([name, value]) => {
+            title = title.replace(new RegExp((0, lodash_escaperegexp_1.default)(`{{${name}}}`), 'g'), value);
+        });
+        await (0, core_1.group)(`Creating PR for ${head} to ${base}`, async () => {
+            try {
+                await createReleaseNotesPR({
+                    base,
+                    prNumber: pullRequestNumber,
+                    prTitle: originalTitle,
+                    prUrl: payload.pull_request.html_url,
+                    releaseNotesFile,
+                    github: github,
+                    head,
+                    labelsToAdd,
+                    owner,
+                    repo,
+                    title,
+                    milestone,
+                    mergedBy: merged_by,
+                });
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error while backporting';
+                (0, core_1.error)(errorMessage);
+                // Create comment
+                await github.issues.createComment({
+                    body: getFailedPRCommentBody({
+                        base,
+                        errorMessage,
+                        head,
+                    }),
+                    issue_number: pullRequestNumber,
+                    owner,
+                    repo,
+                });
+                // Add release-notes-failed label to failures
+                await github.issues.addLabels({
+                    issue_number: pullRequestNumber,
+                    labels: ['release-notes-failed'],
+                    owner,
+                    repo,
+                });
+            }
+        });
+    }
+};
+exports.release = release;
+//# sourceMappingURL=release.js.map

--- a/release-notes-appender/release.ts
+++ b/release-notes-appender/release.ts
@@ -3,13 +3,11 @@ import { context, GitHub } from '@actions/github'
 import { EventPayloads } from '@octokit/webhooks'
 import { cloneRepo } from '../common/git'
 import { exec } from '@actions/exec'
-import escapeRegExp from 'lodash.escaperegexp'
 import { FileAppender } from './FileAppender'
 
-const labelRegExp = /release notes ([^ ]+)(?: ([^ ]+))?$/
+const labelMatcher = 'add-to-release-notes'
 
 const createReleaseNotesPR = async ({
-	base,
 	prNumber,
 	prUrl,
 	prTitle,
@@ -23,7 +21,6 @@ const createReleaseNotesPR = async ({
 	milestone,
 	mergedBy,
 }: {
-	base: string
 	prNumber: number
 	prUrl: string
 	prTitle: string
@@ -41,7 +38,8 @@ const createReleaseNotesPR = async ({
 		await exec('git', args, { cwd: repo })
 	}
 
-	await git('switch', base)
+	await git('checkout', 'main')
+	await git('pull')
 	await git('switch', '--create', head)
 
 	const fileAppender = new FileAppender()
@@ -51,12 +49,12 @@ const createReleaseNotesPR = async ({
 
 	await git('add', releaseNotesFile)
 
-	const body = 'Add PR #' + prNumber + ' to release notes for release ' + base
+	const body = 'Add PR #' + prNumber + ' to release notes for next release'
 	await git('commit', '-m', body)
 
 	await git('push', '--set-upstream', 'origin', head)
 	const createRsp = await github.pulls.create({
-		base,
+		base: 'main',
 		body,
 		head,
 		owner,
@@ -107,79 +105,43 @@ const createReleaseNotesPR = async ({
 	}
 }
 
-const getLabelNames = ({
-	action,
-	label,
-	labels,
-}: {
-	action: EventPayloads.WebhookPayloadPullRequest['action']
-	label: { name: string }
-	labels: EventPayloads.WebhookPayloadPullRequest['pull_request']['labels']
-}): string[] => {
-	switch (action) {
-		case 'closed':
-			return labels.map(({ name }) => name)
-		case 'labeled':
-			return [label.name]
-		default:
-			return []
-	}
-}
-
-const getBackportBaseToHead = ({
-	action,
-	label,
-	labels,
-	pullRequestNumber,
-}: {
-	action: EventPayloads.WebhookPayloadPullRequest['action']
-	label: { name: string }
-	labels: EventPayloads.WebhookPayloadPullRequest['pull_request']['labels']
-	pullRequestNumber: number
-}): { [base: string]: string } => {
-	const baseToHead: { [base: string]: string } = {}
-
-	getLabelNames({ action, label, labels }).forEach((labelName) => {
-		const matches = labelRegExp.exec(labelName)
-
-		if (matches !== null) {
-			const [, base, head = `add-${pullRequestNumber}-to-release-notes-${base}`] = matches
-			baseToHead[base] = head
-		}
-	})
-
-	return baseToHead
-}
-
 const getFailedPRCommentBody = ({
-	base,
+	prNumber,
+	prUrl,
+	prTitle,
+	releaseNotesFile,
 	errorMessage,
 	head,
 }: {
-	base: string
+	prNumber: number
+	prUrl: string
+	prTitle: string
+	releaseNotesFile: string
 	errorMessage: string
 	head: string
 }) => {
 	return [
-		`The backport to \`${base}\` failed:`,
+		`Faile to add PR #${prNumber} to the release notes`,
 		'```',
 		errorMessage,
 		'```',
-		'To create PR manually, run these commands in your terminal:',
+		'To create this PR manually, run these commands in your terminal:',
 		'```bash',
 		'# Fetch latest updates from GitHub',
 		'git fetch',
 		'# Create a new branch',
-		`git switch --create ${head} origin/${base}`,
+		`git switch --create ${head} origin/main`,
 		'# Add the relevant PR to the release notes',
-		'# TODO: include commands for adding PR to release notes',
+		`echo "* [PR #${prNumber}](${prUrl}) - ${prTitle}" >> ${releaseNotesFile}`,
+		`git add ${releaseNotesFile}`,
+		`git commit -m "Add PR #${prNumber} to release notes for next release`,
 		'# Push it to GitHub',
 		`git push --set-upstream origin ${head}`,
 		`git switch main`,
 		'# Remove the local branch',
 		`git branch -D ${head}`,
 		'```',
-		`Then, create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
+		`Then, create a pull request where the \`base\` branch is \`origin/main\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
 	].join('\n')
 }
 
@@ -195,8 +157,6 @@ interface ReleaseArgs {
 const release = async ({
 	labelsToAdd,
 	payload: {
-		action,
-		label,
 		pull_request: {
 			labels,
 			merged,
@@ -221,85 +181,72 @@ const release = async ({
 	let labelsString = labels.map(({ name }) => name)
 	let matches = false
 	for (const label of labelsString) {
-		matches = labelRegExp.test(label)
+		matches = labelMatcher === label
 		if (matches) {
 			break
 		}
 	}
 
+	if (!matches) {
+		console.log("PR doesn't contain label " + labelMatcher + '. Not adding to release notes.')
+		return
+	}
+
 	if (!merged) {
 		console.log('PR not merged')
-		return
+		// 	return
 	}
 	console.log('This is a merge action')
 
-	//TODO: Note that base here is the release version, not any sort of branch
-	const backportBaseToHead = getBackportBaseToHead({
-		action,
-		// The payload has a label property when the action is "labeled".
-		label: label!,
-		labels,
-		pullRequestNumber,
-	})
-
-	if (Object.keys(backportBaseToHead).length === 0) {
-		return
-	}
-
 	await cloneRepo({ token, owner, repo })
 
-	for (const [base, head] of Object.entries(backportBaseToHead)) {
-		let title = titleTemplate
-		Object.entries({
-			base,
-			originalTitle,
-		}).forEach(([name, value]) => {
-			title = title.replace(new RegExp(escapeRegExp(`{{${name}}}`), 'g'), value)
-		})
+	let title = titleTemplate
+	let head = `add-${pullRequestNumber}-to-release-notes`
 
-		await group(`Creating PR for ${head} to ${base}`, async () => {
-			try {
-				await createReleaseNotesPR({
-					base,
+	await group(`Adding ${pullRequestNumber} to release notes for next release`, async () => {
+		try {
+			await createReleaseNotesPR({
+				prNumber: pullRequestNumber,
+				prTitle: originalTitle,
+				prUrl: payload.pull_request.html_url,
+				releaseNotesFile,
+				github: github,
+				head,
+				labelsToAdd,
+				owner,
+				repo,
+				title,
+				milestone,
+				mergedBy: merged_by,
+			})
+		} catch (error) {
+			const errorMessage: string =
+				error instanceof Error ? error.message : 'Unknown error while backporting'
+			logError(errorMessage)
+
+			// Create comment
+			await github.issues.createComment({
+				body: getFailedPRCommentBody({
 					prNumber: pullRequestNumber,
-					prTitle: originalTitle,
 					prUrl: payload.pull_request.html_url,
+					prTitle: originalTitle,
 					releaseNotesFile,
-					github: github,
+					errorMessage,
 					head,
-					labelsToAdd,
-					owner,
-					repo,
-					title,
-					milestone,
-					mergedBy: merged_by,
-				})
-			} catch (error) {
-				const errorMessage: string =
-					error instanceof Error ? error.message : 'Unknown error while backporting'
-				logError(errorMessage)
-
-				// Create comment
-				await github.issues.createComment({
-					body: getFailedPRCommentBody({
-						base,
-						errorMessage,
-						head,
-					}),
-					issue_number: pullRequestNumber,
-					owner,
-					repo,
-				})
-				// Add release-notes-failed label to failures
-				await github.issues.addLabels({
-					issue_number: pullRequestNumber,
-					labels: ['release-notes-failed'],
-					owner,
-					repo,
-				})
-			}
-		})
-	}
+				}),
+				issue_number: pullRequestNumber,
+				owner,
+				repo,
+			})
+			// Add release-notes-failed label to failures
+			await github.issues.addLabels({
+				issue_number: pullRequestNumber,
+				labels: ['release-notes-failed'],
+				owner,
+				repo,
+			})
+		}
+	})
 }
 
 export { release }

--- a/release-notes-appender/release.ts
+++ b/release-notes-appender/release.ts
@@ -179,7 +179,6 @@ const release = async ({
 	token,
 	github,
 }: ReleaseArgs) => {
-	//TODO create interface type for arguments
 	const payload = context.payload as EventPayloads.WebhookPayloadPullRequest
 	console.log('payloadAction: ' + payload.action)
 	let labelsString = labels.map(({ name }) => name)
@@ -198,7 +197,7 @@ const release = async ({
 
 	if (!merged) {
 		console.log('PR not merged')
-		// 	return
+		return
 	}
 	console.log('This is a merge action')
 

--- a/release-notes-appender/release.ts
+++ b/release-notes-appender/release.ts
@@ -1,0 +1,305 @@
+import { error as logError, group } from '@actions/core'
+import { context, GitHub } from '@actions/github'
+import { EventPayloads } from '@octokit/webhooks'
+import { cloneRepo } from '../common/git'
+import { exec } from '@actions/exec'
+import escapeRegExp from 'lodash.escaperegexp'
+import { FileAppender } from './FileAppender'
+
+const labelRegExp = /release notes ([^ ]+)(?: ([^ ]+))?$/
+
+const createReleaseNotesPR = async ({
+	base,
+	prNumber,
+	prUrl,
+	prTitle,
+	releaseNotesFile,
+	github,
+	head,
+	labelsToAdd,
+	owner,
+	repo,
+	title,
+	milestone,
+	mergedBy,
+}: {
+	base: string
+	prNumber: number
+	prUrl: string
+	prTitle: string
+	releaseNotesFile: string
+	github: InstanceType<typeof GitHub>
+	head: string
+	labelsToAdd: string[]
+	owner: string
+	repo: string
+	title: string
+	milestone: EventPayloads.WebhookPayloadPullRequestPullRequestMilestone
+	mergedBy: any
+}) => {
+	const git = async (...args: string[]) => {
+		await exec('git', args, { cwd: repo })
+	}
+
+	await git('switch', base)
+	await git('switch', '--create', head)
+
+	const fileAppender = new FileAppender()
+	fileAppender.loadFile(releaseNotesFile)
+	fileAppender.append('* [PR #' + prNumber + '](' + prUrl + ') - ' + prTitle)
+	fileAppender.writeFile(releaseNotesFile)
+
+	await git('add', releaseNotesFile)
+
+	const body = 'Add PR #' + prNumber + ' to release notes for release ' + base
+	await git('commit', '-m', body)
+
+	await git('push', '--set-upstream', 'origin', head)
+	const createRsp = await github.pulls.create({
+		base,
+		body,
+		head,
+		owner,
+		repo,
+		title,
+	})
+
+	const pullRequestNumber = createRsp.data.number
+
+	// Sync milestone
+	if (milestone && milestone.id) {
+		await github.issues.update({
+			repo,
+			owner,
+			issue_number: pullRequestNumber,
+			milestone: milestone.number,
+		})
+	}
+
+	// Remove default reviewers
+	if (createRsp.data.requested_reviewers) {
+		const reviewers = createRsp.data.requested_reviewers.map((user) => user.login)
+		await github.pulls.deleteReviewRequest({
+			pull_number: pullRequestNumber,
+			repo,
+			owner,
+			reviewers: reviewers,
+		})
+	}
+
+	if (mergedBy) {
+		// Assign to merger
+		await github.pulls.createReviewRequest({
+			pull_number: pullRequestNumber,
+			repo,
+			owner,
+			reviewers: [mergedBy.login],
+		})
+	}
+
+	if (labelsToAdd.length > 0) {
+		await github.issues.addLabels({
+			issue_number: pullRequestNumber,
+			labels: labelsToAdd,
+			owner,
+			repo,
+		})
+	}
+}
+
+const getLabelNames = ({
+	action,
+	label,
+	labels,
+}: {
+	action: EventPayloads.WebhookPayloadPullRequest['action']
+	label: { name: string }
+	labels: EventPayloads.WebhookPayloadPullRequest['pull_request']['labels']
+}): string[] => {
+	switch (action) {
+		case 'closed':
+			return labels.map(({ name }) => name)
+		case 'labeled':
+			return [label.name]
+		default:
+			return []
+	}
+}
+
+const getBackportBaseToHead = ({
+	action,
+	label,
+	labels,
+	pullRequestNumber,
+}: {
+	action: EventPayloads.WebhookPayloadPullRequest['action']
+	label: { name: string }
+	labels: EventPayloads.WebhookPayloadPullRequest['pull_request']['labels']
+	pullRequestNumber: number
+}): { [base: string]: string } => {
+	const baseToHead: { [base: string]: string } = {}
+
+	getLabelNames({ action, label, labels }).forEach((labelName) => {
+		const matches = labelRegExp.exec(labelName)
+
+		if (matches !== null) {
+			const [, base, head = `add-${pullRequestNumber}-to-release-notes-${base}`] = matches
+			baseToHead[base] = head
+		}
+	})
+
+	return baseToHead
+}
+
+const getFailedPRCommentBody = ({
+	base,
+	errorMessage,
+	head,
+}: {
+	base: string
+	errorMessage: string
+	head: string
+}) => {
+	return [
+		`The backport to \`${base}\` failed:`,
+		'```',
+		errorMessage,
+		'```',
+		'To create PR manually, run these commands in your terminal:',
+		'```bash',
+		'# Fetch latest updates from GitHub',
+		'git fetch',
+		'# Create a new branch',
+		`git switch --create ${head} origin/${base}`,
+		'# Add the relevant PR to the release notes',
+		'# TODO: include commands for adding PR to release notes',
+		'# Push it to GitHub',
+		`git push --set-upstream origin ${head}`,
+		`git switch main`,
+		'# Remove the local branch',
+		`git branch -D ${head}`,
+		'```',
+		`Then, create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
+	].join('\n')
+}
+
+interface ReleaseArgs {
+	labelsToAdd: string[]
+	payload: EventPayloads.WebhookPayloadPullRequest
+	titleTemplate: string
+	releaseNotesFile: string
+	token: string
+	github: GitHub
+	sender: EventPayloads.PayloadSender
+}
+const release = async ({
+	labelsToAdd,
+	payload: {
+		action,
+		label,
+		pull_request: {
+			labels,
+			merged,
+			number: pullRequestNumber,
+			title: originalTitle,
+			milestone,
+			merged_by,
+		},
+		repository: {
+			name: repo,
+			owner: { login: owner },
+		},
+	},
+	titleTemplate,
+	releaseNotesFile,
+	token,
+	github,
+}: ReleaseArgs) => {
+	//TODO create interface type for arguments
+	const payload = context.payload as EventPayloads.WebhookPayloadPullRequest
+	console.log('payloadAction: ' + payload.action)
+	let labelsString = labels.map(({ name }) => name)
+	let matches = false
+	for (const label of labelsString) {
+		matches = labelRegExp.test(label)
+		if (matches) {
+			break
+		}
+	}
+
+	if (!merged) {
+		console.log('PR not merged')
+		return
+	}
+	console.log('This is a merge action')
+
+	//TODO: Note that base here is the release version, not any sort of branch
+	const backportBaseToHead = getBackportBaseToHead({
+		action,
+		// The payload has a label property when the action is "labeled".
+		label: label!,
+		labels,
+		pullRequestNumber,
+	})
+
+	if (Object.keys(backportBaseToHead).length === 0) {
+		return
+	}
+
+	await cloneRepo({ token, owner, repo })
+
+	for (const [base, head] of Object.entries(backportBaseToHead)) {
+		let title = titleTemplate
+		Object.entries({
+			base,
+			originalTitle,
+		}).forEach(([name, value]) => {
+			title = title.replace(new RegExp(escapeRegExp(`{{${name}}}`), 'g'), value)
+		})
+
+		await group(`Creating PR for ${head} to ${base}`, async () => {
+			try {
+				await createReleaseNotesPR({
+					base,
+					prNumber: pullRequestNumber,
+					prTitle: originalTitle,
+					prUrl: payload.pull_request.html_url,
+					releaseNotesFile,
+					github: github,
+					head,
+					labelsToAdd,
+					owner,
+					repo,
+					title,
+					milestone,
+					mergedBy: merged_by,
+				})
+			} catch (error) {
+				const errorMessage: string =
+					error instanceof Error ? error.message : 'Unknown error while backporting'
+				logError(errorMessage)
+
+				// Create comment
+				await github.issues.createComment({
+					body: getFailedPRCommentBody({
+						base,
+						errorMessage,
+						head,
+					}),
+					issue_number: pullRequestNumber,
+					owner,
+					repo,
+				})
+				// Add release-notes-failed label to failures
+				await github.issues.addLabels({
+					issue_number: pullRequestNumber,
+					labels: ['release-notes-failed'],
+					owner,
+					repo,
+				})
+			}
+		})
+	}
+}
+
+export { release }

--- a/release-notes-appender/release.ts
+++ b/release-notes-appender/release.ts
@@ -125,7 +125,7 @@ const getFailedPRCommentBody = ({
 	head: string
 }) => {
 	return [
-		`Faile to add PR #${prNumber} to the release notes`,
+		`Failed to add PR #${prNumber} to the release notes`,
 		'```',
 		errorMessage,
 		'```',

--- a/release-notes-appender/release.ts
+++ b/release-notes-appender/release.ts
@@ -42,7 +42,7 @@ const createReleaseNotesPR = async ({
 	await git('pull')
 	await git('switch', '--create', head)
 
-	const fileAppender = new FileAppender()
+	const fileAppender = new FileAppender({ cwd: repo })
 	fileAppender.loadFile(releaseNotesFile)
 	fileAppender.append('* [PR #' + prNumber + '](' + prUrl + ') - ' + prTitle)
 	fileAppender.writeFile(releaseNotesFile)


### PR DESCRIPTION
Release notes are a subset of a CHANGELOG, highlighting the most important and exciting features in a release. Currently, when doing a release of Loki, the person doing the release needs to comb through all the PRs since the last release and decide what's most important, which is a time consuming and error prone process. This action will allow a contributor to add the `add-to-release-notes` label to a PR. When that PR is merged, this will automatically create a PR into the repo that appends the PRs title and number to a file that is a placeholder for the next versions release. This provides 2 advantages.

1. We amortize the release notes collation process over the whole release cycle.
2. The created PR provides an opportunity for the team to consider if the item is actually release notes worthy, and the contributor a chance to think about a good description for the feature asynchronously from the contribution itself. 