### PR TITLE
Allow backporting of type/ci issues

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -13,7 +13,7 @@ const lodash_escaperegexp_1 = __importDefault(require("lodash.escaperegexp"));
 const git_1 = require("../common/git");
 const BETTERER_RESULTS_PATH = '.betterer.results';
 const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/;
-const backportLabels = ['type/docs', 'type/bug', 'product-approved'];
+const backportLabels = ['type/docs', 'type/bug', 'product-approved', 'type/ci'];
 const missingLabels = 'missing-labels';
 const getLabelNames = ({ action, label, labels, }) => {
     switch (action) {
@@ -185,6 +185,7 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                 '* Docs changes.\n',
                 'Please, if the current pull request addresses a bug fix, label it with the `type/bug` label.',
                 'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label.',
+                'If the pull request modifies CI behaviour, please add the `type/ci` label.',
                 'If none of the above applies, please consider removing the backport label and target the next major/minor release.',
                 'Thanks!',
             ].join('\n'),

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -10,7 +10,7 @@ import { cloneRepo } from '../common/git'
 
 const BETTERER_RESULTS_PATH = '.betterer.results'
 const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/
-const backportLabels = ['type/docs', 'type/bug', 'product-approved']
+const backportLabels = ['type/docs', 'type/bug', 'product-approved', 'type/ci']
 const missingLabels = 'missing-labels'
 
 const getLabelNames = ({
@@ -283,6 +283,7 @@ const backport = async ({
 				'* Docs changes.\n',
 				'Please, if the current pull request addresses a bug fix, label it with the `type/bug` label.',
 				'If it already has the product approval, please add the `product-approved` label. For docs changes, please add the `type/docs` label.',
+				'If the pull request modifies CI behaviour, please add the `type/ci` label.',
 				'If none of the above applies, please consider removing the backport label and target the next major/minor release.',
 				'Thanks!',
 			].join('\n'),


### PR DESCRIPTION
@grafana/grafana-delivery has to backport CI changes all the time and picking `product-approved` simply feels weird here 🙂 