### PR TITLE
Stop trying to automatically resolve conflicts for documentation

### DIFF
--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -1,15 +1,7 @@
-import { BETTERER_RESULTS_PATH, isBettererConflict, isDocsConflict } from './backport'
+import { BETTERER_RESULTS_PATH, isBettererConflict } from './backport'
 
 const onlyDocsChanges = ['docs/sources/_index.md', 'docs/sources/other.md']
 const onlyBettererChanges = [BETTERER_RESULTS_PATH]
-
-test('isDocsConflict/onlyDocsChanges', () => {
-	return expect(isDocsConflict(onlyDocsChanges)).resolves.toStrictEqual(true)
-})
-
-test('isDocsConflict/onlyBettererChanges', () => {
-	return expect(isDocsConflict(onlyBettererChanges)).resolves.toStrictEqual(false)
-})
 
 test('isBettererConflict/onlyDocsChanges', () => {
 	return expect(isBettererConflict(onlyDocsChanges)).resolves.toStrictEqual(false)


### PR DESCRIPTION
In practice, resolving docs backports that are non-trivial takes longer than manually creating a backport.

@imatwawana, @chri2547: No need to review, just requesting so that you both know that the auto conflict resolution behavior has been reverted.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
