### PR TITLE
Backports: Add more instructions to failing cherry-pick

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -141,6 +141,8 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
         `git switch --create ${head} origin/${base}`,
         '# Cherry-pick the merged commit of this pull request and resolve the conflicts',
         `git cherry-pick -x ${commitToBackport}`,
+        '# When the conflicts are resolved, stage and commit the changes',
+        `git add . && git commit --no-edit`,
         '# Push it to GitHub',
         `git push --set-upstream origin ${head}`,
         `git switch main`,

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -204,6 +204,8 @@ const getFailedBackportCommentBody = ({
 		`git switch --create ${head} origin/${base}`,
 		'# Cherry-pick the merged commit of this pull request and resolve the conflicts',
 		`git cherry-pick -x ${commitToBackport}`,
+		'# When the conflicts are resolved, stage and commit the changes',
+		`git add . && git commit --no-edit`,
 		'# Push it to GitHub',
 		`git push --set-upstream origin ${head}`,
 		`git switch main`,


### PR DESCRIPTION
Adds `git add . && git commit --no-edit` when the conflicts are resolved