### PR TITLE
Backport: Copy body and all labels from original PR

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -4,15 +4,16 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.backport = void 0;
+exports.backport = exports.getFinalLabels = exports.isBettererConflict = exports.LABEL_NO_CHANGELOG = exports.LABEL_ADD_TO_CHANGELOG = exports.BETTERER_RESULTS_PATH = void 0;
 const core_1 = require("@actions/core");
 const exec_1 = require("@actions/exec");
 const github_1 = require("@actions/github");
 const betterer_1 = require("@betterer/betterer");
 const lodash_escaperegexp_1 = __importDefault(require("lodash.escaperegexp"));
 const git_1 = require("../common/git");
-const BETTERER_RESULTS_PATH = '.betterer.results';
-exports.BETTERER_RESULTS_PATH = BETTERER_RESULTS_PATH;
+exports.BETTERER_RESULTS_PATH = '.betterer.results';
+exports.LABEL_ADD_TO_CHANGELOG = 'add to changelog';
+exports.LABEL_NO_CHANGELOG = 'no-changelog';
 const labelRegExp = /backport ([^ ]+)(?: ([^ ]+))?$/;
 const backportLabels = ['type/docs', 'type/bug', 'product-approved', 'type/ci'];
 const missingLabels = 'missing-labels';
@@ -49,7 +50,7 @@ const getBackportBaseToHead = ({ action, label, labels, pullRequestNumber, }) =>
     return baseToHead;
 };
 const isBettererConflict = async (gitUnmergedPaths) => {
-    return gitUnmergedPaths.length === 1 && gitUnmergedPaths[0] === BETTERER_RESULTS_PATH;
+    return gitUnmergedPaths.length === 1 && gitUnmergedPaths[0] === exports.BETTERER_RESULTS_PATH;
 };
 exports.isBettererConflict = isBettererConflict;
 const backportOnce = async ({ base, body, commitToBackport, github, head, labelsToAdd, owner, repo, title, mergedBy, }) => {
@@ -64,7 +65,7 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
     };
     const fixBettererConflict = async () => {
         await (0, betterer_1.betterer)({ update: true, cwd: repo });
-        await git('add', BETTERER_RESULTS_PATH);
+        await git('add', exports.BETTERER_RESULTS_PATH);
         // Setting -c core.editor=true will prevent the commit message editor from opening
         await git('-c', 'core.editor=true', 'cherry-pick', '--continue');
     };
@@ -75,7 +76,7 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
     }
     catch (error) {
         const gitUnmergedPaths = await gitDiffUnmergedPaths();
-        if (await isBettererConflict(gitUnmergedPaths)) {
+        if (await (0, exports.isBettererConflict)(gitUnmergedPaths)) {
             try {
                 await fixBettererConflict();
             }
@@ -99,6 +100,16 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
         title,
     });
     const pullRequestNumber = createRsp.data.number;
+    // Set the labels first. If setting the reviewers fails for some reason, at
+    // least the labels will be there.
+    if (labelsToAdd.length > 0) {
+        await github.issues.addLabels({
+            issue_number: pullRequestNumber,
+            labels: labelsToAdd,
+            owner,
+            repo,
+        });
+    }
     // Remove default reviewers
     if (createRsp.data.requested_reviewers) {
         const reviewers = createRsp.data.requested_reviewers.map((user) => user.login);
@@ -110,20 +121,13 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
         });
     }
     if (mergedBy) {
+        console.log(`Requesting review from merger: ${mergedBy.login}`);
         // Assign to merger
         await github.pulls.createReviewRequest({
             pull_number: pullRequestNumber,
             repo,
             owner,
             reviewers: [mergedBy.login],
-        });
-    }
-    if (labelsToAdd.length > 0) {
-        await github.issues.addLabels({
-            issue_number: pullRequestNumber,
-            labels: labelsToAdd,
-            owner,
-            repo,
         });
     }
 };
@@ -152,7 +156,7 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
         `Then, create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
     ].join('\n');
 };
-const backport = async ({ labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
+const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_request: { labels, merge_commit_sha: mergeCommitSha, merged, number: pullRequestNumber, title: originalTitle, merged_by, }, repository: { name: repo, owner: { login: owner }, }, }, titleTemplate, token, github, sender, }) => {
     const payload = github_1.context.payload;
     console.log('payloadAction: ' + payload.action);
     if (payload.action !== 'closed') {
@@ -208,6 +212,7 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
             name: missingLabels,
         });
     }
+    const ghIssue = await issue.getIssue();
     if (!merged) {
         console.log('PR not merged');
         return;
@@ -226,9 +231,11 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
     // The merge commit SHA is actually not null.
     const commitToBackport = String(mergeCommitSha);
     (0, core_1.info)(`Backporting ${commitToBackport} from #${pullRequestNumber}`);
+    const originalLabels = ghIssue.labels;
+    const prLabels = Array.from(getFinalLabels(originalLabels, labelsToAdd).values());
     await (0, git_1.cloneRepo)({ token, owner, repo });
     for (const [base, head] of Object.entries(backportBaseToHead)) {
-        const body = `Backport ${commitToBackport} from #${pullRequestNumber}`;
+        const body = `Backport ${commitToBackport} from #${pullRequestNumber}\n\n---\n\n${ghIssue.body}`;
         let title = titleTemplate;
         Object.entries({
             base,
@@ -246,7 +253,7 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                     commitToBackport,
                     github: github,
                     head,
-                    labelsToAdd,
+                    labelsToAdd: prLabels,
                     owner,
                     repo,
                     title,
@@ -254,6 +261,7 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
                 });
             }
             catch (error) {
+                console.log(error);
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error while backporting';
                 (0, core_1.error)(errorMessage);
                 // Create comment
@@ -280,4 +288,33 @@ const backport = async ({ labelsToAdd, payload: { action, label, pull_request: {
     }
 };
 exports.backport = backport;
+/**
+ * getFinalLabels provides the final list of labels that should be set for the
+ * new pull-request.
+ *
+ * @param originalLabels labels provided by the original pull request
+ * @param labelsToAdd labels requested to be added by configuration
+ */
+function getFinalLabels(originalLabels, labelsToAdd) {
+    const result = new Set(originalLabels);
+    // Remove all the labels that started with `backport .*`
+    for (const label of originalLabels) {
+        if (labelRegExp.test(label)) {
+            result.delete(label);
+        }
+    }
+    for (const label of labelsToAdd) {
+        result.add(label);
+        switch (label) {
+            case exports.LABEL_ADD_TO_CHANGELOG:
+                result.delete(exports.LABEL_NO_CHANGELOG);
+                break;
+            case exports.LABEL_NO_CHANGELOG:
+                result.delete(exports.LABEL_ADD_TO_CHANGELOG);
+                break;
+        }
+    }
+    return result;
+}
+exports.getFinalLabels = getFinalLabels;
 //# sourceMappingURL=backport.js.map

--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -1,4 +1,4 @@
-import { BETTERER_RESULTS_PATH, isBettererConflict } from './backport'
+import { BETTERER_RESULTS_PATH, getFinalLabels, isBettererConflict } from './backport'
 
 const onlyDocsChanges = ['docs/sources/_index.md', 'docs/sources/other.md']
 const onlyBettererChanges = [BETTERER_RESULTS_PATH]
@@ -8,4 +8,37 @@ test('isBettererConflict/onlyDocsChanges', () => {
 })
 test('isBettererConflict/onlyBettererChanges', () => {
 	return expect(isBettererConflict(onlyBettererChanges)).resolves.toStrictEqual(true)
+})
+
+test('getFinalLabels/simple', () => {
+	return expect(getFinalLabels(['hello', 'world'], [])).toEqual(new Set(['hello', 'world']))
+})
+
+// All those `backport .*` should be removed from the labels ported over.
+test('getFinalLabels/remove-backports', () => {
+	return expect(getFinalLabels(['backport v10.0.x', 'world'], [])).toEqual(new Set(['world']))
+})
+
+// If a backport label for a specific target is explicitly requested by the
+// configuration, it should still be included.
+test('getFinalLabels/remove-backports-original-only', () => {
+	return expect(getFinalLabels(['backport v10.0.x', 'world'], ['backport v10.0.x'])).toEqual(
+		new Set(['backport v10.0.x', 'world']),
+	)
+})
+
+// If the original PR has the `add to changelog` label set but we explicitly
+// configured `no-changelog`, then the latter should override the first:
+test('getFinalLabels/enforce-no-changelog', () => {
+	return expect(getFinalLabels(['add to changelog', 'world'], ['no-changelog'])).toEqual(
+		new Set(['no-changelog', 'world']),
+	)
+})
+
+// If the original PR has the `no-changelog` label set but we explicitly
+// configured `add to changelog`, then the latter should override the first:
+test('getFinalLabels/enforce-add-to-changelog', () => {
+	return expect(getFinalLabels(['no-changelog', 'world'], ['add to changelog'])).toEqual(
+		new Set(['add to changelog', 'world']),
+	)
 })

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -173,7 +173,15 @@ const backportOnce = async ({
 	}
 
 	if (mergedBy) {
-		console.log(`Requesting review from merger: ${mergedBy.login}`)
+		// If the PR was merged by the same user that owns the token, then we
+		// cannot assign a reviewer.
+		const tokenUser = await github.users.getAuthenticated()
+		if (tokenUser && mergedBy.login === tokenUser.data.login) {
+			console.log(
+				'User who merged the original PR is also the token owner. Skipping reviewer assignment.',
+			)
+			return
+		}
 		// Assign to merger
 		await github.pulls.createReviewRequest({
 			pull_number: pullRequestNumber,
@@ -369,7 +377,6 @@ const backport = async ({
 					mergedBy: merged_by,
 				})
 			} catch (error) {
-				console.log(error)
 				const errorMessage: string =
 					error instanceof Error ? error.message : 'Unknown error while backporting'
 				logError(errorMessage)

--- a/backport/index.js
+++ b/backport/index.js
@@ -20,6 +20,7 @@ class Backport extends Action_1.Action {
     async backport(issue) {
         try {
             await (0, backport_1.backport)({
+                issue,
                 labelsToAdd: (0, exports.getLabelsToAdd)((0, core_1.getInput)('labelsToAdd')),
                 payload: github_1.context.payload,
                 titleTemplate: (0, core_1.getInput)('title'),

--- a/backport/index.ts
+++ b/backport/index.ts
@@ -19,6 +19,7 @@ class Backport extends Action {
 	async backport(issue: OctoKitIssue) {
 		try {
 			await backport({
+				issue,
 				labelsToAdd: getLabelsToAdd(getInput('labelsToAdd')),
 				payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
 				titleTemplate: getInput('title'),


### PR DESCRIPTION
With this PR we should be able to prevent information loss (at least for the automatically generated backports) around the changelog if a backport contains the `add to changelog` label. The PR body is copied to also have the various breaking-changes- and deprecation-notices available.

This PR does not yet tackle manually created backports, though.

<img width="1268" alt="Screenshot 2023-06-13 at 12 31 34" src="https://github.com/grafana/grafana-github-actions/assets/3782/fd698e72-280f-4426-abad-cc8a0a79b7af">

The PR body now contains the old notice that this is backport of some other PR and also (after a horizontal ruler) the original body. Labels are copied and all the `backport .*` ones are removed.

## What about manual backports?

These will come next. I have some ideas around how to tackle that problem (like having grot react to the `backport` table but those ideas are not yet completely finalized.

---

Fixes #147 