### PR TITLE
Bump-version: Use local lerna version

### DIFF
--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -47,9 +47,13 @@ class BumpVersion extends Action_1.Action {
         // create branch
         await git('switch', base);
         await git('switch', '--create', prBranch);
+        // Install dependencies so that we can run lerna et al. with the local
+        // version:
+        await (0, exec_1.exec)('yarn', ['install']);
         // Update version
         await (0, exec_1.exec)('npm', ['version', version, '--no-git-tag-version']);
-        await (0, exec_1.exec)('npx', [
+        await (0, exec_1.exec)('yarn', [
+            'run',
             'lerna',
             'version',
             version,
@@ -75,7 +79,8 @@ class BumpVersion extends Action_1.Action {
         await git('push', '--set-upstream', 'origin', prBranch);
         const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
-		npx lerna version ${version} --no-push --no-git-tag-version --force-publish --exact --yes\n
+		yarn install\n
+		yarn run lerna version ${version} --no-push --no-git-tag-version --force-publish --exact --yes\n
 		yarn install --mode update-lockfile
 		`;
         await octokit.octokit.pulls.create({

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -56,9 +56,13 @@ class BumpVersion extends Action {
 		// create branch
 		await git('switch', base)
 		await git('switch', '--create', prBranch)
+		// Install dependencies so that we can run lerna et al. with the local
+		// version:
+		await exec('yarn', ['install'])
 		// Update version
 		await exec('npm', ['version', version, '--no-git-tag-version'])
-		await exec('npx', [
+		await exec('yarn', [
+			'run',
 			'lerna',
 			'version',
 			version,
@@ -83,7 +87,8 @@ class BumpVersion extends Action {
 		await git('push', '--set-upstream', 'origin', prBranch)
 		const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
-		npx lerna version ${version} --no-push --no-git-tag-version --force-publish --exact --yes\n
+		yarn install\n
+		yarn run lerna version ${version} --no-push --no-git-tag-version --force-publish --exact --yes\n
 		yarn install --mode update-lockfile
 		`
 		await octokit.octokit.pulls.create({


### PR DESCRIPTION
This should avoid compatibility issues between lerna@latest and what we use within grafana/grafana.