### PR TITLE
Backport: Do not copy null-bodies to the backports

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -246,7 +246,9 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
     const prLabels = Array.from(getFinalLabels(originalLabels, labelsToAdd).values());
     await (0, git_1.cloneRepo)({ token, owner, repo });
     for (const [base, head] of Object.entries(backportBaseToHead)) {
-        const body = `Backport ${commitToBackport} from #${pullRequestNumber}\n\n---\n\n${ghIssue.body}`;
+        const issueHasBody = !!ghIssue.body;
+        const bodySuffix = issueHasBody ? `\n\n---\n\n${ghIssue.body}` : '';
+        const body = `Backport ${commitToBackport} from #${pullRequestNumber}${bodySuffix}`;
         let title = titleTemplate;
         Object.entries({
             base,

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -357,7 +357,9 @@ const backport = async ({
 	await cloneRepo({ token, owner, repo })
 
 	for (const [base, head] of Object.entries(backportBaseToHead)) {
-		const body = `Backport ${commitToBackport} from #${pullRequestNumber}\n\n---\n\n${ghIssue.body}`
+		const issueHasBody = !!ghIssue.body
+		const bodySuffix = issueHasBody ? `\n\n---\n\n${ghIssue.body}` : ''
+		const body = `Backport ${commitToBackport} from #${pullRequestNumber}${bodySuffix}`
 
 		let title = titleTemplate
 		Object.entries({


### PR DESCRIPTION
Basically, if the original pull-request had an empty body, the body of the backport looked like this:

```
Backport ... from ...

---

null
```

With this change it should now only look like this:

```
Backport ... from ...
```