### PR TITLE
Grafana Delivery: Add `grafana-delivery-bot` user

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -262,6 +262,7 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
     const originalLabels = ghIssue.labels;
     const prLabels = Array.from(getFinalLabels(originalLabels, labelsToAdd).values());
     await (0, git_1.cloneRepo)({ token, owner, repo });
+    await (0, git_1.setConfig)('grafana-delivery-bot');
     for (const [base, head] of Object.entries(backportBaseToHead)) {
         const issueHasBody = !!ghIssue.body;
         const bodySuffix = issueHasBody ? `\n\n---\n\n${ghIssue.body}` : '';

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -6,7 +6,7 @@ import { context, GitHub } from '@actions/github'
 import { betterer } from '@betterer/betterer'
 import { EventPayloads } from '@octokit/webhooks'
 import escapeRegExp from 'lodash.escaperegexp'
-import { cloneRepo } from '../common/git'
+import { cloneRepo, setConfig } from '../common/git'
 import { OctoKitIssue } from '../api/octokit'
 
 export const BETTERER_RESULTS_PATH = '.betterer.results'
@@ -372,6 +372,7 @@ const backport = async ({
 	const prLabels = Array.from(getFinalLabels(originalLabels, labelsToAdd).values())
 
 	await cloneRepo({ token, owner, repo })
+	await setConfig('grafana-delivery-bot')
 
 	for (const [base, head] of Object.entries(backportBaseToHead)) {
 		const issueHasBody = !!ghIssue.body

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -17,6 +17,7 @@ class BumpVersion extends Action_1.Action {
         const { owner, repo } = github_1.context.repo;
         const token = this.getToken();
         await (0, git_1.cloneRepo)({ token, owner, repo });
+        await (0, git_1.setConfig)('grafana-delivery-bot');
         process.chdir(repo);
         if (!this.isCalledFromWorkflow()) {
             // Manually invoked the action

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -4,7 +4,7 @@ import { context } from '@actions/github'
 // import { OctoKitIssue } from '../api/octokit'
 import { Action } from '../common/Action'
 import { exec } from '@actions/exec'
-import { cloneRepo } from '../common/git'
+import { cloneRepo, setConfig } from '../common/git'
 // import fs from 'fs'
 import { OctoKit } from '../api/octokit'
 import { getVersionMatch } from './versions'
@@ -17,6 +17,7 @@ class BumpVersion extends Action {
 		const token = this.getToken()
 
 		await cloneRepo({ token, owner, repo })
+		await setConfig('grafana-delivery-bot')
 
 		process.chdir(repo)
 

--- a/common/git.js
+++ b/common/git.js
@@ -1,11 +1,30 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.cloneRepo = void 0;
+exports.cloneRepo = exports.setConfig = void 0;
 const exec_1 = require("@actions/exec");
+const grafanaBotProps = { userEmail: 'bot@grafana.com', userName: 'grafanabot' };
+const grafanaDeliveryBotProps = {
+    userEmail: '132647405+grafana-delivery-bot[bot]@users.noreply.github.com',
+    userName: 'grafana-delivery-bot[bot]',
+};
+async function setConfig(botSlug) {
+    let configProps;
+    switch (botSlug) {
+        case 'grafanabot':
+            configProps = grafanaBotProps;
+            break;
+        case 'grafana-delivery-bot':
+            configProps = grafanaDeliveryBotProps;
+            break;
+        default:
+            throw Error('Users available: grafanabot and grafana-delivery-bot, please add another user if that is the case');
+    }
+    await (0, exec_1.exec)('git', ['config', '--global', 'user.email', configProps.userEmail]);
+    await (0, exec_1.exec)('git', ['config', '--global', 'user.name', configProps.userName]);
+}
+exports.setConfig = setConfig;
 async function cloneRepo({ token, owner, repo }) {
     await (0, exec_1.exec)('git', ['clone', `https://x-access-token:${token}@github.com/${owner}/${repo}.git`]);
-    await (0, exec_1.exec)('git', ['config', '--global', 'user.email', 'bot@grafana.com']);
-    await (0, exec_1.exec)('git', ['config', '--global', 'user.name', 'grafanabot']);
 }
 exports.cloneRepo = cloneRepo;
 //# sourceMappingURL=git.js.map

--- a/common/git.ts
+++ b/common/git.ts
@@ -6,8 +6,35 @@ export interface CloneProps {
 	repo: string
 }
 
+export interface ConfigProps {
+	userEmail: string
+	userName: string
+}
+
+const grafanaBotProps: ConfigProps = { userEmail: 'bot@grafana.com', userName: 'grafanabot' }
+const grafanaDeliveryBotProps: ConfigProps = {
+	userEmail: '132647405+grafana-delivery-bot[bot]@users.noreply.github.com',
+	userName: 'grafana-delivery-bot[bot]',
+}
+
+export async function setConfig(botSlug: string) {
+	let configProps: ConfigProps
+	switch (botSlug) {
+		case 'grafanabot':
+			configProps = grafanaBotProps
+			break
+		case 'grafana-delivery-bot':
+			configProps = grafanaDeliveryBotProps
+			break
+		default:
+			throw Error(
+				'Users available: grafanabot and grafana-delivery-bot, please add another user if that is the case',
+			)
+	}
+	await exec('git', ['config', '--global', 'user.email', configProps.userEmail])
+	await exec('git', ['config', '--global', 'user.name', configProps.userName])
+}
+
 export async function cloneRepo({ token, owner, repo }: CloneProps) {
 	await exec('git', ['clone', `https://x-access-token:${token}@github.com/${owner}/${repo}.git`])
-	await exec('git', ['config', '--global', 'user.email', 'bot@grafana.com'])
-	await exec('git', ['config', '--global', 'user.name', 'grafanabot'])
 }

--- a/release-notes-appender/release.js
+++ b/release-notes-appender/release.js
@@ -118,6 +118,7 @@ const release = async ({ labelsToAdd, payload: { pull_request: { labels, merged,
     }
     console.log('This is a merge action');
     await (0, git_1.cloneRepo)({ token, owner, repo });
+    await (0, git_1.setConfig)('grafanabot');
     await (0, core_1.group)(`Adding ${pullRequestNumber} to release notes for next release`, async () => {
         let head = `add-${pullRequestNumber}-to-release-notes`;
         let title = titleTemplate;

--- a/release-notes-appender/release.ts
+++ b/release-notes-appender/release.ts
@@ -5,7 +5,7 @@ import { exec } from '@actions/exec'
 import escapeRegExp from 'lodash.escaperegexp'
 
 import { FileAppender } from './FileAppender'
-import { cloneRepo } from '../common/git'
+import { cloneRepo, setConfig } from '../common/git'
 
 const labelMatcher = 'add-to-release-notes'
 
@@ -202,6 +202,7 @@ const release = async ({
 	console.log('This is a merge action')
 
 	await cloneRepo({ token, owner, repo })
+	await setConfig('grafanabot')
 
 	await group(`Adding ${pullRequestNumber} to release notes for next release`, async () => {
 		let head = `add-${pullRequestNumber}-to-release-notes`

--- a/update-changelog/index.js
+++ b/update-changelog/index.js
@@ -26,6 +26,7 @@ class UpdateChangelog extends Action_1.Action {
         const versionSplitted = version.split('.');
         const versionMajorBranch = 'v' + versionSplitted[0] + '.' + versionSplitted[1] + '.' + 'x';
         await (0, git_1.cloneRepo)({ token, owner, repo });
+        await (0, git_1.setConfig)('grafana-delivery-bot');
         process.chdir(repo);
         const fileUpdater = new FileUpdater_1.FileUpdater();
         const builder = new ChangelogBuilder_1.ChangelogBuilder(octokit, version);

--- a/update-changelog/index.ts
+++ b/update-changelog/index.ts
@@ -4,7 +4,7 @@ import { context } from '@actions/github'
 // import { OctoKitIssue } from '../api/octokit'
 import { Action } from '../common/Action'
 import { exec } from '@actions/exec'
-import { cloneRepo } from '../common/git'
+import { cloneRepo, setConfig } from '../common/git'
 import { OctoKit } from '../api/octokit'
 import { FileUpdater } from './FileUpdater'
 import { ChangelogBuilder } from './ChangelogBuilder'
@@ -22,6 +22,7 @@ class UpdateChangelog extends Action {
 		const versionMajorBranch = 'v' + versionSplitted[0] + '.' + versionSplitted[1] + '.' + 'x'
 
 		await cloneRepo({ token, owner, repo })
+		await setConfig('grafana-delivery-bot')
 
 		process.chdir(repo)
 


### PR DESCRIPTION
In this PR we add `grafana-delivery-bot` user for Grafana Delivery related github actions.
Up until now, `grafanabot` was signing all the commits, while we should start taking ownership of some of the gh actions that are delivery related.