### PR TITLE
Backport: gh pr command with labels and original body

### DIFF
--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -53,7 +53,7 @@ test('getFinalLabels/enforce-add-to-changelog', () => {
 	)
 })
 
-test('getFailedBackportCommentBody/gh-line', () => {
+test('getFailedBackportCommentBody/gh-line-no-body', () => {
 	const output = getFailedBackportCommentBody({
 		base: 'v10.0.x',
 		commitToBackport: '123456',
@@ -61,8 +61,26 @@ test('getFailedBackportCommentBody/gh-line', () => {
 		head: 'backport-123-to-v10.0.x',
 		title: '[v10.0.x] hello world',
 		originalNumber: 123,
+		labels: ['backport'],
+		hasBody: false,
 	})
 	expect(output).toContain(
-		'gh pr create --title "[v10.0.x] hello world" --body "Backport 123456 from #123" --label backport --base v10.0.x --milestone 10.0.x --web',
+		'gh pr create --title "[v10.0.x] hello world" --body "Backport 123456 from #123" --label "backport" --base v10.0.x --milestone 10.0.x --web',
+	)
+})
+
+test('getFailedBackportCommentBody/gh-line-with-body', () => {
+	const output = getFailedBackportCommentBody({
+		base: 'v10.0.x',
+		commitToBackport: '123456',
+		errorMessage: 'some error',
+		head: 'backport-123-to-v10.0.x',
+		title: '[v10.0.x] hello world',
+		originalNumber: 123,
+		labels: ['backport', 'no-changelog'],
+		hasBody: true,
+	})
+	expect(output).toContain(
+		'gh pr create --title "[v10.0.x] hello world" --body-file .pr-body.txt --label "backport" --label "no-changelog" --base v10.0.x --milestone 10.0.x --web',
 	)
 })


### PR DESCRIPTION
This PR extends the "failed backport" comment with the labels set by the original PR (as done in the automated PR) and also copies the description over using `gh pr view`:

```bash
# Fetch latest updates from GitHub
git fetch
# Create a new branch
git switch --create backport-36-to-v10.0.x origin/v10.0.x
# Cherry-pick the merged commit of this pull request and resolve the conflicts
git cherry-pick -x 27d3466ba916670a8f3ae0277d5224da900d7a61
# When the conflicts are resolved, stage and commit the changes
git add . && git cherry-pick --continue
# If you have the GitHub CLI installed: Push the branch to GitHub and a PR:
gh pr view 36 --json body --template 'Backport 27d3466ba916670a8f3ae0277d5224da900d7a61 from #36{{ "\n\n---\n\n" }}{{ index . "body" }}' > .pr-body.txt
gh pr create --title "[v10.0.x] Update README.md" --body-file .pr-body.txt --label "type/docs" --label "no-changelog" --label "backport" --base v10.0.x --milestone 10.0.x --web
# If you don't have the GitHub CLI installed: Push the branch to GitHub and manually create a PR:
git push --set-upstream origin backport-36-to-v10.0.x
# Remove the local backport branch
git switch main
git branch -D backport-36-to-v10.0.x
```

If the original PR did not contain any description, then the new body is defined inline (as it was done before this PR).

Fixes https://github.com/grafana/grafana-delivery/issues/178