### PR TITLE
Seperate failed backport instructions into seperate code blocks

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -165,11 +165,15 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
         `git cherry-pick -x ${commitToBackport}`,
         '# When the conflicts are resolved, stage and commit the changes',
         `git add . && git cherry-pick --continue`,
-        '# If you have the GitHub CLI installed: Push the branch to GitHub and a PR:',
+        '```',
+        'If you have the [GitHub CLI](https://cli.github.com/) installed:',
+        '```bash',
     ];
     if (hasBody) {
         lines = lines.concat([
+            '# Create the PR body template',
             `gh pr view ${originalNumber} --json body --template 'Backport ${commitToBackport} from #${originalNumber}{{ "\\n\\n---\\n\\n" }}{{ index . "body" }}' > .pr-body.txt`,
+            `# Push the branch to GitHub and a PR`,
             `gh pr create --title "${escapedTitle}" --body-file .pr-body.txt ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`,
         ]);
     }
@@ -179,6 +183,9 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
         ]);
     }
     lines = lines.concat([
+        '```',
+        `Or, if you don't have the GitHub CLI installed ([we recommend you install it!](https://github.com/cli/cli#installation)):`,
+        '```bash',
         "# If you don't have the GitHub CLI installed: Push the branch to GitHub and manually create a PR:",
         `git push --set-upstream origin ${head}`,
         '# Remove the local backport branch',

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -236,12 +236,16 @@ export const getFailedBackportCommentBody = ({
 		`git cherry-pick -x ${commitToBackport}`,
 		'# When the conflicts are resolved, stage and commit the changes',
 		`git add . && git cherry-pick --continue`,
-		'# If you have the GitHub CLI installed: Push the branch to GitHub and a PR:',
+		'```',
+		'If you have the [GitHub CLI](https://cli.github.com/) installed:',
+		'```bash',
 	]
 
 	if (hasBody) {
 		lines = lines.concat([
+			'# Create the PR body template',
 			`gh pr view ${originalNumber} --json body --template 'Backport ${commitToBackport} from #${originalNumber}{{ "\\n\\n---\\n\\n" }}{{ index . "body" }}' > .pr-body.txt`,
+			`# Push the branch to GitHub and a PR`,
 			`gh pr create --title "${escapedTitle}" --body-file .pr-body.txt ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`,
 		])
 	} else {
@@ -251,6 +255,9 @@ export const getFailedBackportCommentBody = ({
 	}
 
 	lines = lines.concat([
+		'```',
+		`Or, if you don't have the GitHub CLI installed ([we recommend you install it!](https://github.com/cli/cli#installation)):`,
+		'```bash',
 		"# If you don't have the GitHub CLI installed: Push the branch to GitHub and manually create a PR:",
 		`git push --set-upstream origin ${head}`,
 		'# Remove the local backport branch',


### PR DESCRIPTION
This PR separates the gh and non-gh instructions into seperate code blocks to try and make them easier to understand as two distinct options.


Here's what it looks like:

---

The backport to `v10.0.x` failed:
```
some error
```
To backport manually, run these commands in your terminal:
```bash
# Fetch latest updates from GitHub
git fetch
# Create a new branch
git switch --create backport-123-to-v10.0.x origin/v10.0.x
# Cherry-pick the merged commit of this pull request and resolve the conflicts
git cherry-pick -x 123456
# When the conflicts are resolved, stage and commit the changes
git add . && git cherry-pick --continue
```
If you have the [GitHub CLI](https://cli.github.com/) installed:
```bash
# Create the PR body template
gh pr view 123 --json body --template 'Backport 123456 from #123{{ "\n\n---\n\n" }}{{ index . "body" }}' > .pr-body.txt
# Push the branch to GitHub and a PR
gh pr create --title "[v10.0.x] hello world" --body-file .pr-body.txt --label "backport" --label "no-changelog" --base v10.0.x --milestone 10.0.x --web
```
Or, if you don't have the GitHub CLI installed ([we recommend you install it!](https://github.com/cli/cli#installation)):
```bash
# If you don't have the GitHub CLI installed: Push the branch to GitHub and manually create a PR:
git push --set-upstream origin backport-123-to-v10.0.x
# Remove the local backport branch
git switch main
git branch -D backport-123-to-v10.0.x
```
Unless you've used the GitHub CLI above, now create a pull request where the `base` branch is `v10.0.x` and the `compare`/`head` branch is `backport-123-to-v10.0.x`.
