### PR TITLE
Bump-version: Add precommit hook

### DIFF
--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -9,6 +9,9 @@ inputs:
     required: false
   version_call:
     description: Version number invoked from workflow
+  precommit_make_target:
+    required: false
+    description: Make target to execute before the changes are committed for the PR
 runs:
   using: 'node16'
   main: 'index.js'

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -8,6 +8,7 @@ const Action_1 = require("../common/Action");
 const exec_1 = require("@actions/exec");
 const git_1 = require("../common/git");
 const versions_1 = require("./versions");
+const utils_1 = require("../common/utils");
 class BumpVersion extends Action_1.Action {
     constructor() {
         super(...arguments);
@@ -74,6 +75,10 @@ class BumpVersion extends Action_1.Action {
         }
         catch (e) {
             console.error('yarn failed', e);
+        }
+        const precommitMakeTarget = (0, utils_1.getInput)('precommit_make_target');
+        if (precommitMakeTarget) {
+            await (0, exec_1.exec)('make', [precommitMakeTarget]);
         }
         await git('commit', '-am', `"Release: Updated versions in package to ${version}"`);
         // push

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -8,6 +8,7 @@ import { cloneRepo, setConfig } from '../common/git'
 // import fs from 'fs'
 import { OctoKit } from '../api/octokit'
 import { getVersionMatch } from './versions'
+import { getInput } from '../common/utils'
 
 class BumpVersion extends Action {
 	id = 'BumpVersion'
@@ -83,6 +84,12 @@ class BumpVersion extends Action {
 		} catch (e) {
 			console.error('yarn failed', e)
 		}
+
+		const precommitMakeTarget = getInput('precommit_make_target')
+		if (precommitMakeTarget) {
+			await exec('make', [precommitMakeTarget])
+		}
+
 		await git('commit', '-am', `"Release: Updated versions in package to ${version}"`)
 		// push
 		await git('push', '--set-upstream', 'origin', prBranch)


### PR DESCRIPTION
The idea of this change is to allow projects to define additional code that should be executed *before* the PR with the updated files is created. This way things like the `make gen-cue` command can be executed by the grafana/grafana project.

For a project to add such custom commands, it has to include a Make target for it and then set it as `precommit_make_target` input to this action. E.g.:

```yaml
      - name: Run bump version
        uses: ./actions/bump-version
        with:
          precommit_make_target: gen-cue
```

This relates to https://github.com/grafana/grafana/issues/73880.