### PR TITLE
fix(backport): Add git push to manual backport instructions

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -171,14 +171,19 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
     ];
     if (hasBody) {
         lines = lines.concat([
+            '# Push the branch to GitHub:',
+            `git push --set-upstream origin ${head}`,
             '# Create the PR body template',
             `PR_BODY=$(gh pr view ${originalNumber} --json body --template 'Backport ${commitToBackport} from #${originalNumber}{{ "\\n\\n---\\n\\n" }}{{ index . "body" }}')`,
-            `# Push the branch to GitHub and a PR`,
+            `# Create the PR on GitHub`,
             `echo "$\{PR_BODY\}" | gh pr create --title "${escapedTitle}" --body-file - ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`, //eslint-disable-line
         ]);
     }
     else {
         lines = lines.concat([
+            '# Push the branch to GitHub:',
+            `git push --set-upstream origin ${head}`,
+            `# Create the PR on GitHub`,
             `gh pr create --title "${escapedTitle}" --body "${baseBody}" ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`,
         ]);
     }
@@ -186,13 +191,15 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
         '```',
         `Or, if you don't have the GitHub CLI installed ([we recommend you install it!](https://github.com/cli/cli#installation)):`,
         '```bash',
-        "# If you don't have the GitHub CLI installed: Push the branch to GitHub and manually create a PR:",
+        '# Push the branch to GitHub:',
         `git push --set-upstream origin ${head}`,
+        '',
+        `# Create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
+        '',
         '# Remove the local backport branch',
         `git switch main`,
         `git branch -D ${head}`,
         '```',
-        `Unless you've used the GitHub CLI above, now create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
     ]);
     return lines.join('\n');
 };

--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -67,6 +67,7 @@ test('getFailedBackportCommentBody/gh-line-no-body', () => {
 	expect(output).toContain(
 		'gh pr create --title "[v10.0.x] hello world" --body "Backport 123456 from #123" --label "backport" --base v10.0.x --milestone 10.0.x --web',
 	)
+	expect(output).toContain('git push --set-upstream origin backport-123-to-v10.0.x')
 })
 
 test('getFailedBackportCommentBody/gh-line-with-body', () => {
@@ -81,6 +82,8 @@ test('getFailedBackportCommentBody/gh-line-with-body', () => {
 		hasBody: true,
 	})
 	expect(output).toContain(
-		'gh pr create --title "[v10.0.x] hello world" --body-file .pr-body.txt --label "backport" --label "no-changelog" --base v10.0.x --milestone 10.0.x --web',
+		'gh pr create --title "[v10.0.x] hello world" --body-file - --label "backport" --label "no-changelog" --base v10.0.x --milestone 10.0.x --web',
 	)
+	console.log(output)
+	expect(output).toContain('git push --set-upstream origin backport-123-to-v10.0.x')
 })

--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -84,6 +84,5 @@ test('getFailedBackportCommentBody/gh-line-with-body', () => {
 	expect(output).toContain(
 		'gh pr create --title "[v10.0.x] hello world" --body-file - --label "backport" --label "no-changelog" --base v10.0.x --milestone 10.0.x --web',
 	)
-	console.log(output)
 	expect(output).toContain('git push --set-upstream origin backport-123-to-v10.0.x')
 })

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -243,13 +243,18 @@ export const getFailedBackportCommentBody = ({
 
 	if (hasBody) {
 		lines = lines.concat([
+			'# Push the branch to GitHub:',
+			`git push --set-upstream origin ${head}`,
 			'# Create the PR body template',
 			`PR_BODY=$(gh pr view ${originalNumber} --json body --template 'Backport ${commitToBackport} from #${originalNumber}{{ "\\n\\n---\\n\\n" }}{{ index . "body" }}')`,
-			`# Push the branch to GitHub and a PR`,
+			`# Create the PR on GitHub`,
 			`echo "$\{PR_BODY\}" | gh pr create --title "${escapedTitle}" --body-file - ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`, //eslint-disable-line
 		])
 	} else {
 		lines = lines.concat([
+			'# Push the branch to GitHub:',
+			`git push --set-upstream origin ${head}`,
+			`# Create the PR on GitHub`,
 			`gh pr create --title "${escapedTitle}" --body "${baseBody}" ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`,
 		])
 	}
@@ -258,13 +263,15 @@ export const getFailedBackportCommentBody = ({
 		'```',
 		`Or, if you don't have the GitHub CLI installed ([we recommend you install it!](https://github.com/cli/cli#installation)):`,
 		'```bash',
-		"# If you don't have the GitHub CLI installed: Push the branch to GitHub and manually create a PR:",
+		'# Push the branch to GitHub:',
 		`git push --set-upstream origin ${head}`,
+		'',
+		`# Create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
+		'',
 		'# Remove the local backport branch',
 		`git switch main`,
 		`git branch -D ${head}`,
 		'```',
-		`Unless you've used the GitHub CLI above, now create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
 	])
 
 	return lines.join('\n')


### PR DESCRIPTION
This will also include the `git push` instruction to the manual backport guide and move some of the other instructions around a bit.

```
    To backport manually, run these commands in your terminal:
    ```bash
    # Fetch latest updates from GitHub
    git fetch
    # Create a new branch
    git switch --create backport-123-to-v10.0.x origin/v10.0.x
    # Cherry-pick the merged commit of this pull request and resolve the conflicts
    git cherry-pick -x 123456
    # When the conflicts are resolved, stage and commit the changes
    git add . && git cherry-pick --continue
    ```
    If you have the [GitHub CLI](https://cli.github.com/) installed:
    ```bash
    # Push the branch to GitHub:
    git push --set-upstream origin backport-123-to-v10.0.x
    # Create the PR body template
    PR_BODY=$(gh pr view 123 --json body --template 'Backport 123456 from #123{{ \"\\n\\n---\\n\\n\" }}{{ index . \"body\" }}')
    # Create the PR on GitHub
    echo \"${PR_BODY}\" | gh pr create --title \"[v10.0.x] hello world\" --body-file - --label \"backport\" --label \"no-changelog\" --base v10.0.x --milestone 10.0.x --web
    ```
    Or, if you don't have the GitHub CLI installed ([we recommend you install it!](https://github.com/cli/cli#installation)):
    ```bash
    # Push the branch to GitHub:
    git push --set-upstream origin backport-123-to-v10.0.x·
    # Create a pull request where the `base` branch is `v10.0.x` and the `compare`/`head` branch is `backport-123-to-v10.0.x`.·
    # Remove the local backport branch
    git switch main
    git branch -D backport-123-to-v10.0.x
    ```
```