### PR TITLE
Post a PR comment when a backport is requested (via labels)

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -265,6 +265,11 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
     const ghIssue = await issue.getIssue();
     if (!merged) {
         console.log('PR not merged');
+        for await (const cmt of issue.getComments()) {
+            if (cmt.at.toString().indexOf('This PR must be merged before a backport PR will be created.') >= 0) {
+                return;
+            }
+        }
         await github.issues.createComment({
             body: 'This PR must be merged before a backport PR will be created.',
             issue_number: pullRequestNumber,

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -265,6 +265,12 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
     const ghIssue = await issue.getIssue();
     if (!merged) {
         console.log('PR not merged');
+        await github.issues.createComment({
+            body: 'This PR must be merged before a backport PR will be created.',
+            issue_number: pullRequestNumber,
+            owner,
+            repo,
+        });
         return;
     }
     console.log('This is a merge action');

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -374,6 +374,12 @@ const backport = async ({
 
 	if (!merged) {
 		console.log('PR not merged')
+		await github.issues.createComment({
+			body: 'This PR must be merged before a backport PR will be created.',
+			issue_number: pullRequestNumber,
+			owner,
+			repo,
+		})
 		return
 	}
 	console.log('This is a merge action')

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -374,6 +374,11 @@ const backport = async ({
 
 	if (!merged) {
 		console.log('PR not merged')
+		for await (const cmt of issue.getComments()) {
+			if (cmt.at.toString().indexOf('This PR must be merged before a backport PR will be created.') >= 0) {
+				return
+			}
+		}
 		await github.issues.createComment({
 			body: 'This PR must be merged before a backport PR will be created.',
 			issue_number: pullRequestNumber,


### PR DESCRIPTION
I've never really used the backport action before, it was really unclear to me initially that the original PR has to be merged before the backport PR will be created. 

I'm not sure if I agree that that's the right workflow, why would we not want to open the backport PR asap? The branch can still be updated. In either way, the change here would have helped me avoid some confusing.