### PR TITLE
MilestoneCheck: don't run the milestone check on label/unlabel

### DIFF
--- a/pr-checks/checks/MilestoneCheck.js
+++ b/pr-checks/checks/MilestoneCheck.js
@@ -10,7 +10,7 @@ class MilestoneCheck extends Check_1.Check {
         this.id = 'milestone';
     }
     subscribe(s) {
-        s.on(['pull_request', 'pull_request_target'], ['opened', 'reopened', 'ready_for_review', 'synchronize', 'labeled', 'unlabeled'], async (ctx) => {
+        s.on(['pull_request', 'pull_request_target'], ['opened', 'reopened', 'ready_for_review', 'synchronize'], async (ctx) => {
             const pr = github_1.context.payload.pull_request;
             if (pr && pr.milestone) {
                 return this.success(ctx, pr.head.sha);

--- a/pr-checks/checks/MilestoneCheck.test.ts
+++ b/pr-checks/checks/MilestoneCheck.test.ts
@@ -7,7 +7,7 @@ import { CheckState } from '../types'
 import { MilestoneCheck } from './MilestoneCheck'
 
 const prEvents = ['pull_request', 'pull_request_target']
-const prActions = ['opened', 'reopened', 'ready_for_review', 'synchronize', 'labeled', 'unlabeled']
+const prActions = ['opened', 'reopened', 'ready_for_review', 'synchronize']
 
 const prTestCases = prEvents
 	.flatMap((event) => {

--- a/pr-checks/checks/MilestoneCheck.ts
+++ b/pr-checks/checks/MilestoneCheck.ts
@@ -20,7 +20,7 @@ export class MilestoneCheck extends Check {
 	subscribe(s: CheckSubscriber) {
 		s.on(
 			['pull_request', 'pull_request_target'],
-			['opened', 'reopened', 'ready_for_review', 'synchronize', 'labeled', 'unlabeled'],
+			['opened', 'reopened', 'ready_for_review', 'synchronize'],
 			async (ctx) => {
 				const pr = context.payload.pull_request as EventPayloads.WebhookPayloadPullRequestPullRequest
 


### PR DESCRIPTION
- currently we rerun the milestone check any time a label changes
- this seems unnecessary as there's no logic related to labels in the milestone check. there's either a milestone (✅ ) or there isn't (❌)
- i think this might be a cause of the milestone check being more unreliable than the other checks. these are the action runs that triggered when https://github.com/grafana/grafana/pull/80280 was opened:
  - ![image](https://github.com/grafana/grafana-github-actions/assets/20999846/b8bf2110-71e6-4017-80fb-f54a0bacd596)
  - looking at the timestamps from the last 2 (the `milestoned` and `labelled` events)...
  - the action triggered by the `milestoned` event ran at 11:30:23 and took 29s, meaning it finished at 11:30:52
  - the action triggered by the `labelled` event ran at 11:30:01 and took 57s, meaning it finished at 11:30:58
  - so despite the `milestoned` event triggering **after** the labelled event, it actually **finished** before
  - i think the action triggered by the `labelled` event then finishes after and overwrites the successful result of the action triggered by the `milestoned` event with the failed result of the action triggered by the `labelled` event
  - this could maybe still happen without these labelled events, but it can't hurt to remove them anyway and find out? 🤷 
