### PR TITLE
fix unintentional runs of backport action

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -224,6 +224,10 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
             break;
         }
     }
+    // don't execute the rest of the backport if there's no backport label present
+    if (!matches) {
+        return;
+    }
     if (matches && matchedLabels.length == 0 && !labelsString.includes(missingLabels)) {
         console.log('PR intended to be backported, but not labeled properly. Labels: ' +
             labelsString +

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -330,6 +330,10 @@ const backport = async ({
 			break
 		}
 	}
+	// don't execute the rest of the backport if there's no backport label present
+	if (!matches) {
+		return
+	}
 	if (matches && matchedLabels.length == 0 && !labelsString.includes(missingLabels)) {
 		console.log(
 			'PR intended to be backported, but not labeled properly. Labels: ' +


### PR DESCRIPTION
This should allow us to skip running the rest of the backport function if we don't find a backport label. AFAICT previously we would always run the backport even if there wasn't a backport label present.