### PR TITLE
Skip milestone check if milestone is not needed

### DIFF
--- a/pr-checks/checks/MilestoneCheck.js
+++ b/pr-checks/checks/MilestoneCheck.js
@@ -12,12 +12,15 @@ class MilestoneCheck extends Check_1.Check {
     subscribe(s) {
         s.on(['pull_request', 'pull_request_target'], ['opened', 'reopened', 'ready_for_review', 'synchronize'], async (ctx) => {
             const pr = github_1.context.payload.pull_request;
-            // Milestones are relevant only for PRs against `main`.
-            // If base branch is not `main`, we can skip the check
-            if (!!pr?.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'main') {
+            if (!pr) {
+                return this.failure(ctx, '');
+            }
+            // We ignore PRs whose base branch is not `main`, since milestones are relevant only for `main`.
+            // We add some sanity checks on the payload for extra precaution.
+            if (pr.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'main') {
                 return;
             }
-            if (pr && pr.milestone) {
+            if (pr.milestone) {
                 return this.success(ctx, pr.head.sha);
             }
             return this.failure(ctx, pr.head.sha);

--- a/pr-checks/checks/MilestoneCheck.js
+++ b/pr-checks/checks/MilestoneCheck.js
@@ -14,7 +14,7 @@ class MilestoneCheck extends Check_1.Check {
             const pr = github_1.context.payload.pull_request;
             // Milestones are relevant only for PRs against `main`.
             // If base branch is not `main`, we can skip the check
-            if (!!pr?.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'refs/heads/main') {
+            if (!!pr?.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'main') {
                 return;
             }
             if (pr && pr.milestone) {

--- a/pr-checks/checks/MilestoneCheck.js
+++ b/pr-checks/checks/MilestoneCheck.js
@@ -12,6 +12,11 @@ class MilestoneCheck extends Check_1.Check {
     subscribe(s) {
         s.on(['pull_request', 'pull_request_target'], ['opened', 'reopened', 'ready_for_review', 'synchronize'], async (ctx) => {
             const pr = github_1.context.payload.pull_request;
+            // Milestones are relevant only for PRs against `main`.
+            // If base branch is not `main`, we can skip the check
+            if (!!pr?.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'refs/heads/main') {
+                return;
+            }
             if (pr && pr.milestone) {
                 return this.success(ctx, pr.head.sha);
             }

--- a/pr-checks/checks/MilestoneCheck.js
+++ b/pr-checks/checks/MilestoneCheck.js
@@ -15,10 +15,12 @@ class MilestoneCheck extends Check_1.Check {
             if (!pr) {
                 return this.failure(ctx, '');
             }
-            // We ignore PRs whose base branch is not `main`, since milestones are relevant only for `main`.
-            // We add some sanity checks on the payload for extra precaution.
-            if (pr.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'main') {
-                return;
+            // This check is relevant only for PRs opened against some specific branches.
+            // We can skip it if the base branch is not one of those.
+            // If for any reason the base branch is not specified in the webhook event payload, we still run the check
+            const versionBranchRegex = /v\d*\.\d*\.\d*.*/;
+            if (pr.base?.ref && pr.base.ref !== 'main' && !versionBranchRegex.test(pr.base.ref)) {
+                return this.success(ctx, pr.head.sha);
             }
             if (pr.milestone) {
                 return this.success(ctx, pr.head.sha);

--- a/pr-checks/checks/MilestoneCheck.test.ts
+++ b/pr-checks/checks/MilestoneCheck.test.ts
@@ -18,7 +18,7 @@ const prTestCases = prEvents
 	})
 	.flatMap((tc) => [
 		{
-			testCaseName: 'without milestone set',
+			testCaseName: 'without milestone set, when base branch is not specified in PR payload',
 			eventName: tc.eventName,
 			action: tc.action,
 			checkState: CheckState.Failure,
@@ -26,12 +26,44 @@ const prTestCases = prEvents
 			pull_request_payload: {},
 		},
 		{
-			testCaseName: 'with milestone set',
+			testCaseName: 'without milestone set, with `main` as base branch',
+			eventName: tc.eventName,
+			action: tc.action,
+			checkState: CheckState.Failure,
+			description: 'Failed',
+			pull_request_payload: { milestone: undefined, base: { ref: 'main' } },
+		},
+		{
+			testCaseName: 'without milestone set, with version branch as base branch',
+			eventName: tc.eventName,
+			action: tc.action,
+			checkState: CheckState.Failure,
+			description: 'Failed',
+			pull_request_payload: { milestone: undefined, base: { ref: 'v10.2.3' } },
+		},
+		{
+			testCaseName: 'with milestone set, when base branch is not specified in PR payload',
 			eventName: tc.eventName,
 			action: tc.action,
 			checkState: CheckState.Success,
 			description: 'Milestone set',
 			pull_request_payload: { milestone: {} },
+		},
+		{
+			testCaseName: 'with milestone set, with `main` as base branch',
+			eventName: tc.eventName,
+			action: tc.action,
+			checkState: CheckState.Success,
+			description: 'Milestone set',
+			pull_request_payload: { milestone: {}, base: { ref: 'main' } },
+		},
+		{
+			testCaseName: 'with milestone set, with version branch as base branch',
+			eventName: tc.eventName,
+			action: tc.action,
+			checkState: CheckState.Success,
+			description: 'Milestone set',
+			pull_request_payload: { milestone: {}, base: { ref: 'v10.2.3' } },
 		},
 	])
 

--- a/pr-checks/checks/MilestoneCheck.ts
+++ b/pr-checks/checks/MilestoneCheck.ts
@@ -24,6 +24,12 @@ export class MilestoneCheck extends Check {
 			async (ctx) => {
 				const pr = context.payload.pull_request as EventPayloads.WebhookPayloadPullRequestPullRequest
 
+				// Milestones are relevant only for PRs against `main`.
+				// If base branch is not `main`, we can skip the check
+				if (!!pr?.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'refs/heads/main') {
+					return
+				}
+
 				if (pr && pr.milestone) {
 					return this.success(ctx, pr.head.sha)
 				}

--- a/pr-checks/checks/MilestoneCheck.ts
+++ b/pr-checks/checks/MilestoneCheck.ts
@@ -24,13 +24,17 @@ export class MilestoneCheck extends Check {
 			async (ctx) => {
 				const pr = context.payload.pull_request as EventPayloads.WebhookPayloadPullRequestPullRequest
 
-				// Milestones are relevant only for PRs against `main`.
-				// If base branch is not `main`, we can skip the check
-				if (!!pr?.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'main') {
+				if (!pr) {
+					return this.failure(ctx, '')
+				}
+
+				// We ignore PRs whose base branch is not `main`, since milestones are relevant only for `main`.
+				// We add some sanity checks on the payload for extra precaution.
+				if (pr.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'main') {
 					return
 				}
 
-				if (pr && pr.milestone) {
+				if (pr.milestone) {
 					return this.success(ctx, pr.head.sha)
 				}
 

--- a/pr-checks/checks/MilestoneCheck.ts
+++ b/pr-checks/checks/MilestoneCheck.ts
@@ -26,7 +26,7 @@ export class MilestoneCheck extends Check {
 
 				// Milestones are relevant only for PRs against `main`.
 				// If base branch is not `main`, we can skip the check
-				if (!!pr?.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'refs/heads/main') {
+				if (!!pr?.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'main') {
 					return
 				}
 

--- a/pr-checks/checks/MilestoneCheck.ts
+++ b/pr-checks/checks/MilestoneCheck.ts
@@ -27,11 +27,11 @@ export class MilestoneCheck extends Check {
 				if (!pr) {
 					return this.failure(ctx, '')
 				}
-				
+
 				// This check is relevant only for PRs opened against some specific branches.
 				// We can skip it if the base branch is not one of those.
 				// If for any reason the base branch is not specified in the webhook event payload, we still run the check
-				const versionBranchRegex = /v\d*\.\d*\.\d*.*/; 
+				const versionBranchRegex = /v\d*\.\d*\.\d*.*/
 				if (pr.base?.ref && pr.base.ref !== 'main' && !versionBranchRegex.test(pr.base.ref)) {
 					return this.success(ctx, pr.head.sha)
 				}

--- a/pr-checks/checks/MilestoneCheck.ts
+++ b/pr-checks/checks/MilestoneCheck.ts
@@ -27,11 +27,13 @@ export class MilestoneCheck extends Check {
 				if (!pr) {
 					return this.failure(ctx, '')
 				}
-
-				// We ignore PRs whose base branch is not `main`, since milestones are relevant only for `main`.
-				// We add some sanity checks on the payload for extra precaution.
-				if (pr.base?.ref && typeof pr.base.ref === 'string' && pr.base.ref !== 'main') {
-					return
+				
+				// This check is relevant only for PRs opened against some specific branches.
+				// We can skip it if the base branch is not one of those.
+				// If for any reason the base branch is not specified in the webhook event payload, we still run the check
+				const versionBranchRegex = /v\d*\.\d*\.\d*.*/; 
+				if (pr.base?.ref && pr.base.ref !== 'main' && !versionBranchRegex.test(pr.base.ref)) {
+					return this.success(ctx, pr.head.sha)
 				}
 
 				if (pr.milestone) {


### PR DESCRIPTION
Proposal to skip the check on the milestone if the PR that triggered the check has not been opened against `main`.

Note: I have check that `pull_request.base.ref` is actually `main` when the base branch is `main`. Real example of payload:
```
{
  ...
  "pull_requests": [
    {
      ...
      "base": {
        "ref": "main",
        ...
      }
    }
  ]
}
```
However, I've not tested the changes by running the updated check in the CI yet.