### PR TITLE
Bump Version: Replace lerna with Nx release

### DIFF
--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -379,7 +379,9 @@ const backport = async ({
 	if (!merged) {
 		console.log('PR not merged')
 		for await (const cmt of issue.getComments()) {
-			if (cmt.at.toString().indexOf('This PR must be merged before a backport PR will be created.') >= 0) {
+			if (
+				cmt.at.toString().indexOf('This PR must be merged before a backport PR will be created.') >= 0
+			) {
 				return
 			}
 		}

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -53,7 +53,7 @@ class BumpVersion extends Action_1.Action {
         await (0, exec_1.exec)('yarn', ['install']);
         // Update root package.json version
         await (0, exec_1.exec)('npm', ['version', version, '--no-git-tag-version']);
-        // Update all npm packages package.json version that use fixed versioning strategy (aligned with grafana version)
+        // Update the npm packages and plugins package.json versions to align with grafana version.
         await (0, exec_1.exec)('yarn', [
             'nx',
             'release',
@@ -62,8 +62,8 @@ class BumpVersion extends Action_1.Action {
             '--no-git-commit',
             '--no-git-tag',
             '--no-stage-changes',
-            '--group',
-            'fixed',
+            '--groups',
+            'grafanaPackages,plugins',
         ]);
         try {
             //regenerate yarn.lock file
@@ -86,7 +86,7 @@ class BumpVersion extends Action_1.Action {
         const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
 		yarn install\n
-		yarn nx release version ${version} --no-git-commit --no-git-tag --no-stage-changes --group fixed\n
+		yarn nx release version ${version} --no-git-commit --no-git-tag --no-stage-changes --groups grafanaPackages,plugins\n
 		yarn install --mode update-lockfile
 		`;
         await octokit.octokit.pulls.create({

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -1,4 +1,7 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 // import { error as logError, getInput, setFailed } from '@actions/core'
 const github_1 = require("@actions/github");
@@ -7,6 +10,7 @@ const github_1 = require("@actions/github");
 const Action_1 = require("../common/Action");
 const exec_1 = require("@actions/exec");
 const git_1 = require("../common/git");
+const fs_1 = __importDefault(require("fs"));
 const versions_1 = require("./versions");
 const utils_1 = require("../common/utils");
 class BumpVersion extends Action_1.Action {
@@ -46,6 +50,21 @@ class BumpVersion extends Action_1.Action {
     async onTriggeredBase(octokit, base, version) {
         const { owner, repo } = github_1.context.repo;
         const prBranch = `bump-version-${version}`;
+        const hasLerna = fs_1.default.existsSync('lerna.json');
+        // Lerna was replaced with Nx release in 11.1.0. For backwards compatibility we support both
+        const versionCmd = hasLerna
+            ? [
+                'run',
+                'lerna',
+                'version',
+                version,
+                '--no-push',
+                '--no-git-tag-version',
+                '--force-publish',
+                '--exact',
+                '--yes',
+            ]
+            : ['nx', 'release', 'version', version, '--groups', 'grafanaPackages,privatePackages,plugins'];
         // create branch
         await git('switch', base);
         await git('switch', '--create', prBranch);
@@ -54,14 +73,7 @@ class BumpVersion extends Action_1.Action {
         // Update root package.json version
         await (0, exec_1.exec)('npm', ['version', version, '--no-git-tag-version']);
         // Update the npm packages and plugins package.json versions to align with grafana version.
-        await (0, exec_1.exec)('yarn', [
-            'nx',
-            'release',
-            'version',
-            version,
-            '--groups',
-            'grafanaPackages,privatePackages,plugins',
-        ]);
+        await (0, exec_1.exec)('yarn', versionCmd);
         try {
             //regenerate yarn.lock file
             //await exec('npm', ['install', '-g', 'corepack'])
@@ -83,7 +95,7 @@ class BumpVersion extends Action_1.Action {
         const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
 		yarn install\n
-		yarn nx release version ${version} --groups grafanaPackages,privatePackages,plugins\n
+		yarn ${versionCmd.join(' ')}\n
 		yarn install --mode update-lockfile
 		`;
         await octokit.octokit.pulls.create({

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -51,7 +51,7 @@ class BumpVersion extends Action_1.Action {
         const { owner, repo } = github_1.context.repo;
         const prBranch = `bump-version-${version}`;
         const hasLerna = fs_1.default.existsSync('lerna.json');
-        // Lerna was replaced with Nx release in 11.1.0. For backwards compatibility we support both
+        // Lerna was replaced with Nx release after 11.5.0. For backwards compatibility we support both
         const versionCmd = hasLerna
             ? [
                 'run',

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -59,11 +59,8 @@ class BumpVersion extends Action_1.Action {
             'release',
             'version',
             version,
-            '--no-git-commit',
-            '--no-git-tag',
-            '--no-stage-changes',
             '--groups',
-            'grafanaPackages,plugins',
+            'grafanaPackages,privatePackages,plugins',
         ]);
         try {
             //regenerate yarn.lock file
@@ -86,7 +83,7 @@ class BumpVersion extends Action_1.Action {
         const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
 		yarn install\n
-		yarn nx release version ${version} --no-git-commit --no-git-tag --no-stage-changes --groups grafanaPackages,plugins\n
+		yarn nx release version ${version} --groups grafanaPackages,privatePackages,plugins\n
 		yarn install --mode update-lockfile
 		`;
         await octokit.octokit.pulls.create({

--- a/bump-version/index.js
+++ b/bump-version/index.js
@@ -49,21 +49,21 @@ class BumpVersion extends Action_1.Action {
         // create branch
         await git('switch', base);
         await git('switch', '--create', prBranch);
-        // Install dependencies so that we can run lerna et al. with the local
-        // version:
+        // Install dependencies so that we can run versioning commands
         await (0, exec_1.exec)('yarn', ['install']);
-        // Update version
+        // Update root package.json version
         await (0, exec_1.exec)('npm', ['version', version, '--no-git-tag-version']);
+        // Update all npm packages package.json version that use fixed versioning strategy (aligned with grafana version)
         await (0, exec_1.exec)('yarn', [
-            'run',
-            'lerna',
+            'nx',
+            'release',
             'version',
             version,
-            '--no-push',
-            '--no-git-tag-version',
-            '--force-publish',
-            '--exact',
-            '--yes',
+            '--no-git-commit',
+            '--no-git-tag',
+            '--no-stage-changes',
+            '--group',
+            'fixed',
         ]);
         try {
             //regenerate yarn.lock file
@@ -86,7 +86,7 @@ class BumpVersion extends Action_1.Action {
         const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
 		yarn install\n
-		yarn run lerna version ${version} --no-push --no-git-tag-version --force-publish --exact --yes\n
+		yarn nx release version ${version} --no-git-commit --no-git-tag --no-stage-changes --group fixed\n
 		yarn install --mode update-lockfile
 		`;
         await octokit.octokit.pulls.create({

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -56,7 +56,7 @@ class BumpVersion extends Action {
 		const { owner, repo } = context.repo
 		const prBranch = `bump-version-${version}`
 		const hasLerna = fs.existsSync('lerna.json')
-		// Lerna was replaced with Nx release in 11.1.0. For backwards compatibility we support both
+		// Lerna was replaced with Nx release after 11.5.0. For backwards compatibility we support both
 		const versionCmd = hasLerna
 			? [
 					'run',

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -58,21 +58,21 @@ class BumpVersion extends Action {
 		// create branch
 		await git('switch', base)
 		await git('switch', '--create', prBranch)
-		// Install dependencies so that we can run lerna et al. with the local
-		// version:
+		// Install dependencies so that we can run versioning commands
 		await exec('yarn', ['install'])
-		// Update version
+		// Update root package.json version
 		await exec('npm', ['version', version, '--no-git-tag-version'])
+		// Update all npm packages package.json version that use fixed versioning strategy (aligned with grafana version)
 		await exec('yarn', [
-			'run',
-			'lerna',
+			'nx',
+			'release',
 			'version',
 			version,
-			'--no-push',
-			'--no-git-tag-version',
-			'--force-publish',
-			'--exact',
-			'--yes',
+			'--no-git-commit',
+			'--no-git-tag',
+			'--no-stage-changes',
+			'--group',
+			'fixed',
 		])
 		try {
 			//regenerate yarn.lock file
@@ -96,7 +96,7 @@ class BumpVersion extends Action {
 		const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
 		yarn install\n
-		yarn run lerna version ${version} --no-push --no-git-tag-version --force-publish --exact --yes\n
+		yarn nx release version ${version} --no-git-commit --no-git-tag --no-stage-changes --group fixed\n
 		yarn install --mode update-lockfile
 		`
 		await octokit.octokit.pulls.create({

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -62,7 +62,7 @@ class BumpVersion extends Action {
 		await exec('yarn', ['install'])
 		// Update root package.json version
 		await exec('npm', ['version', version, '--no-git-tag-version'])
-		// Update all npm packages package.json version that use fixed versioning strategy (aligned with grafana version)
+		// Update the npm packages and plugins package.json versions to align with grafana version.
 		await exec('yarn', [
 			'nx',
 			'release',
@@ -71,9 +71,10 @@ class BumpVersion extends Action {
 			'--no-git-commit',
 			'--no-git-tag',
 			'--no-stage-changes',
-			'--group',
-			'fixed',
+			'--groups',
+			'grafanaPackages,plugins',
 		])
+
 		try {
 			//regenerate yarn.lock file
 			//await exec('npm', ['install', '-g', 'corepack'])
@@ -96,7 +97,7 @@ class BumpVersion extends Action {
 		const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
 		yarn install\n
-		yarn nx release version ${version} --no-git-commit --no-git-tag --no-stage-changes --group fixed\n
+		yarn nx release version ${version} --no-git-commit --no-git-tag --no-stage-changes --groups grafanaPackages,plugins\n
 		yarn install --mode update-lockfile
 		`
 		await octokit.octokit.pulls.create({

--- a/bump-version/index.ts
+++ b/bump-version/index.ts
@@ -68,11 +68,8 @@ class BumpVersion extends Action {
 			'release',
 			'version',
 			version,
-			'--no-git-commit',
-			'--no-git-tag',
-			'--no-stage-changes',
 			'--groups',
-			'grafanaPackages,plugins',
+			'grafanaPackages,privatePackages,plugins',
 		])
 
 		try {
@@ -97,7 +94,7 @@ class BumpVersion extends Action {
 		const body = `Executed:\n
 		npm version ${version} --no-git-tag-version\n
 		yarn install\n
-		yarn nx release version ${version} --no-git-commit --no-git-tag --no-stage-changes --groups grafanaPackages,plugins\n
+		yarn nx release version ${version} --groups grafanaPackages,privatePackages,plugins\n
 		yarn install --mode update-lockfile
 		`
 		await octokit.octokit.pulls.create({


### PR DESCRIPTION
This PR adds the ability to version bump the npm packages in grafana/grafana with either lerna or NX release (depending on whether a lerna.json file exists in the root of the grafana repo).

## Why?

See [this issue](https://github.com/grafana/grafana/issues/85402). TLDR; once these PRs are all merged we have the ability to create versioning strategies for different packages fixing the age old problem of "how do I add an NPM package to Grafana that doesn't get versioned and released with Grafana releases".

Associated PRs:

- https://github.com/grafana/grafana-build/pull/294
- https://github.com/grafana/grafana/pull/85403


