### PR TITLE
Use single quotes to avoid shell evaluation when copy-pasting commands

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -149,7 +149,7 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
     const backportMilestone = base.startsWith('v') ? base.substring(1) : base;
     const escapedTitle = title.replaceAll('"', '\\"');
     const baseBody = `Backport ${commitToBackport} from #${originalNumber}`;
-    const joinedLabels = labels.map((l) => `--label "${l}"`).join(' ');
+    const joinedLabels = labels.map((l) => `--label '${l}'`).join(' ');
     let lines = [
         `The backport to \`${base}\` failed:`,
         '```',

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -178,7 +178,7 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
             '# Create the PR body template',
             `PR_BODY=$(gh pr view ${originalNumber} --json body --template 'Backport ${commitToBackport} from #${originalNumber}{{ "\\n\\n---\\n\\n" }}{{ index . "body" }}')`,
             `# Create the PR on GitHub`,
-            `echo "$\{PR_BODY\}" | gh pr create --title "${escapedTitle}" --body-file - ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`, //eslint-disable-line
+            `echo "$\{PR_BODY\}" | gh pr create --title '${escapedTitle}' --body-file - ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`, //eslint-disable-line
         ]);
     }
     else {
@@ -186,7 +186,7 @@ const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, he
             '# Push the branch to GitHub:',
             `git push --set-upstream origin ${head}`,
             `# Create the PR on GitHub`,
-            `gh pr create --title "${escapedTitle}" --body "${baseBody}" ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`,
+            `gh pr create --title '${escapedTitle}' --body '${baseBody}' ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`,
         ]);
     }
     lines = lines.concat([

--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -65,7 +65,7 @@ test('getFailedBackportCommentBody/gh-line-no-body', () => {
 		hasBody: false,
 	})
 	expect(output).toContain(
-		'gh pr create --title "[v10.0.x] hello world" --body "Backport 123456 from #123" --label "backport" --base v10.0.x --milestone 10.0.x --web',
+		`gh pr create --title '[v10.0.x] hello world' --body 'Backport 123456 from #123' --label 'backport' --base v10.0.x --milestone 10.0.x --web`,
 	)
 	expect(output).toContain('git push --set-upstream origin backport-123-to-v10.0.x')
 })
@@ -82,7 +82,7 @@ test('getFailedBackportCommentBody/gh-line-with-body', () => {
 		hasBody: true,
 	})
 	expect(output).toContain(
-		'gh pr create --title "[v10.0.x] hello world" --body-file - --label "backport" --label "no-changelog" --base v10.0.x --milestone 10.0.x --web',
+		`gh pr create --title '[v10.0.x] hello world' --body-file - --label 'backport' --label 'no-changelog' --base v10.0.x --milestone 10.0.x --web`,
 	)
 	expect(output).toContain('git push --set-upstream origin backport-123-to-v10.0.x')
 })

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -250,14 +250,14 @@ export const getFailedBackportCommentBody = ({
 			'# Create the PR body template',
 			`PR_BODY=$(gh pr view ${originalNumber} --json body --template 'Backport ${commitToBackport} from #${originalNumber}{{ "\\n\\n---\\n\\n" }}{{ index . "body" }}')`,
 			`# Create the PR on GitHub`,
-			`echo "$\{PR_BODY\}" | gh pr create --title "${escapedTitle}" --body-file - ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`, //eslint-disable-line
+			`echo "$\{PR_BODY\}" | gh pr create --title '${escapedTitle}' --body-file - ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`, //eslint-disable-line
 		])
 	} else {
 		lines = lines.concat([
 			'# Push the branch to GitHub:',
 			`git push --set-upstream origin ${head}`,
 			`# Create the PR on GitHub`,
-			`gh pr create --title "${escapedTitle}" --body "${baseBody}" ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`,
+			`gh pr create --title '${escapedTitle}' --body '${baseBody}' ${joinedLabels} --base ${base} --milestone ${backportMilestone} --web`,
 		])
 	}
 
@@ -379,7 +379,9 @@ const backport = async ({
 	if (!merged) {
 		console.log('PR not merged')
 		for await (const cmt of issue.getComments()) {
-			if (cmt.at.toString().indexOf('This PR must be merged before a backport PR will be created.') >= 0) {
+			if (
+				cmt.at.toString().indexOf('This PR must be merged before a backport PR will be created.') >= 0
+			) {
 				return
 			}
 		}

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -220,7 +220,7 @@ export const getFailedBackportCommentBody = ({
 	const backportMilestone = base.startsWith('v') ? base.substring(1) : base
 	const escapedTitle = title.replaceAll('"', '\\"')
 	const baseBody = `Backport ${commitToBackport} from #${originalNumber}`
-	const joinedLabels = labels.map((l) => `--label "${l}"`).join(' ')
+	const joinedLabels = labels.map((l) => `--label '${l}'`).join(' ')
 	let lines = [
 		`The backport to \`${base}\` failed:`,
 		'```',


### PR DESCRIPTION
Otherwise Markdown backticks are evaluated and someone could feasibly craft a malicious title.