### PR TITLE
Replace all GraphQL calls with REST API calls

### DIFF
--- a/backport/index.js
+++ b/backport/index.js
@@ -20,7 +20,6 @@ class Backport extends Action_1.Action {
     async backport(issue) {
         try {
             await (0, backport_1.backport)({
-                issue,
                 labelsToAdd: (0, exports.getLabelsToAdd)((0, core_1.getInput)('labelsToAdd')),
                 payload: github_1.context.payload,
                 titleTemplate: (0, core_1.getInput)('title'),

--- a/backport/index.ts
+++ b/backport/index.ts
@@ -16,10 +16,9 @@ class Backport extends Action {
 		return this.backport(issue)
 	}
 
-	async backport(issue: OctoKitIssue) {
+	async backport(issue : OctoKitIssue) {
 		try {
 			await backport({
-				issue,
 				labelsToAdd: getLabelsToAdd(getInput('labelsToAdd')),
 				payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
 				titleTemplate: getInput('title'),


### PR DESCRIPTION
The default GitHub Actions app token, `secrets.GITHUB_TOKEN`, cannot make GraphQL calls. Without this patch, the cherry-pick and PR opening succeeds but then a confusing error comment is posted back on the original PR like in https://github.com/grafana/pyroscope/actions/runs/10606280342/job/29396725224?pr=3526.

Removing the GraphQL call means that this workflow doesn't require GitHub App creation for each repository that wants to use it.