### PR TITLE
Enhance issue commands to assign all projects at once

### DIFF
--- a/api/octokit.js
+++ b/api/octokit.js
@@ -15,13 +15,6 @@ let numRequests = 0;
 const getNumRequests = () => numRequests;
 exports.getNumRequests = getNumRequests;
 class OctoKit {
-    get octokit() {
-        numRequests++;
-        return this._octokit;
-    }
-    get octokitGraphQL() {
-        return this._octokitGraphQL;
-    }
     constructor(token, params, options = { readonly: false }) {
         this.token = token;
         this.params = params;
@@ -38,6 +31,13 @@ class OctoKit {
             },
         });
         console.debug('Constructor OctoKit end');
+    }
+    get octokit() {
+        numRequests++;
+        return this._octokit;
+    }
+    get octokitGraphQL() {
+        return this._octokitGraphQL;
     }
     // TODO: just iterate over the issues in a page here instead of making caller do it
     async *query(query) {

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -15,6 +15,13 @@ let numRequests = 0;
 const getNumRequests = () => numRequests;
 exports.getNumRequests = getNumRequests;
 class OctoKit {
+    get octokit() {
+        numRequests++;
+        return this._octokit;
+    }
+    get octokitGraphQL() {
+        return this._octokitGraphQL;
+    }
     constructor(token, params, options = { readonly: false }) {
         this.token = token;
         this.params = params;
@@ -31,13 +38,6 @@ class OctoKit {
             },
         });
         console.debug('Constructor OctoKit end');
-    }
-    get octokit() {
-        numRequests++;
-        return this._octokit;
-    }
-    get octokitGraphQL() {
-        return this._octokitGraphQL;
     }
     // TODO: just iterate over the issues in a page here instead of making caller do it
     async *query(query) {

--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -70,8 +70,8 @@ class Commands {
                 return 'memberOf' in command ? isMember : !isMember;
             }
         }
-        if ('label' in this.action) {
-            return command.type === 'label' && this.action.label === command.name;
+        if ('label' in this.action && command.type === 'label' && this.action.label === command.name) {
+            return true;
         }
         console.debug(`Current issue labels: ${issue.labels.join(' ')}`);
         // If the command is a label and the issue has the label, execute the command

--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -73,10 +73,11 @@ class Commands {
         if ('label' in this.action && command.type === 'label' && this.action.label === command.name) {
             return true;
         }
-        console.debug(`Current issue labels: ${issue.labels.join(' ')}`);
-        // If the command is a label and the issue has the label, execute the command
-        if (command.type === 'label' && issue.labels.includes(command.name)) {
-            console.debug(`Command ${command.type} matched the issue ${issue.number} and has the label ${command.name}. All labels: ${issue.labels.join(' ')}`);
+        // If the command is a label, the issue has the label and the action is addToProject, execute the command
+        // This is to allow the pipeline to add multiple projects at once based on all the issue labels
+        if (command.type === 'label' &&
+            command.action === 'addToProject' &&
+            issue.labels.includes(command.name)) {
             return true;
         }
         return false;

--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -73,6 +73,7 @@ class Commands {
         if ('label' in this.action) {
             return command.type === 'label' && this.action.label === command.name;
         }
+        console.debug(`Current issue labels: ${issue.labels.join(' ')}`);
         // If the command is a label and the issue has the label, execute the command
         if (command.type === 'label' && issue.labels.includes(command.name)) {
             console.debug(`Command ${command.type} matched the issue ${issue.number} and has the label ${command.name}. All labels: ${issue.labels.join(' ')}`);

--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -73,6 +73,11 @@ class Commands {
         if ('label' in this.action) {
             return command.type === 'label' && this.action.label === command.name;
         }
+        // If the command is a label and the issue has the label, execute the command
+        if (command.type === 'label' && issue.labels.includes(command.name)) {
+            console.debug(`Command ${command.type} matched the issue ${issue.number} and has the label ${command.name}. All labels: ${issue.labels.join(' ')}`);
+            return true;
+        }
         return false;
     }
     async perform(command, issue, changedFiles) {

--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -168,7 +168,9 @@ class Commands {
             console.log('Found changedfiles commands, listing pull request filenames...');
             changedFiles = await this.github.listPullRequestFilenames();
         }
-        console.debug('Would perform commands:', this.config);
+        console.debug('----- Current Commands configuration -----');
+        console.debug(this.config);
+        console.debug('----- End of Commands configuration -----');
         return Promise.all(this.config.map((command) => this.perform(command, issue, changedFiles)));
     }
 }

--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -82,7 +82,7 @@ class Commands {
         return false;
     }
     async perform(command, issue, changedFiles) {
-        console.debug('Would perform command:', command, ' on issue:', issue);
+        console.debug('Would try to perform command:', command, ' on issue:', issue);
         if (!(await this.matches(command, issue, changedFiles))) {
             console.debug('Command ', JSON.stringify(command), ' did not match any criteria');
             return;

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -14,13 +14,19 @@ export type Command = { name: string } & (
 	| { type: 'comment'; allowUsers: string[] }
 	| { type: 'label' }
 	| { type: 'changedfiles'; matches: string | string[] | { any: string[] } | { all: string[] } }
-	| { type: 'author'; memberOf?: { org: string }; notMemberOf?: { org: string }; ignoreList?: string[]; noLabels?: boolean }
+	| {
+			type: 'author'
+			memberOf?: { org: string }
+			notMemberOf?: { org: string }
+			ignoreList?: string[]
+			noLabels?: boolean
+	  }
 ) & {
 		action?: 'close' | 'addToProject' | 'removeFromProject'
 	} & Partial<{ comment: string; addLabel: string; removeLabel: string }> &
-	Partial<{ requireLabel: string; disallowLabel: string }>
-	& Partial<{ addToProject: { url: string, org?: string, column?: string } }>
-	& Partial<{ removeFromProject: { url: string, org?: string } }>
+	Partial<{ requireLabel: string; disallowLabel: string }> &
+	Partial<{ addToProject: { url: string; org?: string; column?: string } }> &
+	Partial<{ removeFromProject: { url: string; org?: string } }>
 /* eslint-enable */
 
 export class Commands {
@@ -233,7 +239,9 @@ export class Commands {
 			console.log('Found changedfiles commands, listing pull request filenames...')
 			changedFiles = await this.github.listPullRequestFilenames()
 		}
-		console.debug('Would perform commands:', this.config)
+		console.debug('----- Current Commands configuration -----')
+		console.debug(this.config)
+		console.debug('----- End of Commands configuration -----')
 		return Promise.all(this.config.map((command) => this.perform(command, issue, changedFiles)))
 	}
 }

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -121,7 +121,7 @@ export class Commands {
 	}
 
 	private async perform(command: Command, issue: Issue, changedFiles: string[]) {
-		console.debug('Would perform command:', command, ' on issue:', issue)
+		console.debug('Would try to perform command:', command, ' on issue:', issue)
 		if (!(await this.matches(command, issue, changedFiles))) {
 			console.debug('Command ', JSON.stringify(command), ' did not match any criteria')
 			return

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -106,14 +106,13 @@ export class Commands {
 			return true
 		}
 
-		console.debug(`Current issue labels: ${issue.labels.join(' ')}`)
-		// If the command is a label and the issue has the label, execute the command
-		if (command.type === 'label' && issue.labels.includes(command.name)) {
-			console.debug(
-				`Command ${command.type} matched the issue ${issue.number} and has the label ${
-					command.name
-				}. All labels: ${issue.labels.join(' ')}`,
-			)
+		// If the command is a label, the issue has the label and the action is addToProject, execute the command
+		// This is to allow the pipeline to add multiple projects at once based on all the issue labels
+		if (
+			command.type === 'label' &&
+			command.action === 'addToProject' &&
+			issue.labels.includes(command.name)
+		) {
 			return true
 		}
 

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -106,6 +106,7 @@ export class Commands {
 			return command.type === 'label' && this.action.label === command.name
 		}
 
+		console.debug(`Current issue labels: ${issue.labels.join(' ')}`)
 		// If the command is a label and the issue has the label, execute the command
 		if (command.type === 'label' && issue.labels.includes(command.name)) {
 			console.debug(

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -102,8 +102,8 @@ export class Commands {
 			}
 		}
 
-		if ('label' in this.action) {
-			return command.type === 'label' && this.action.label === command.name
+		if ('label' in this.action && command.type === 'label' && this.action.label === command.name) {
+			return true
 		}
 
 		console.debug(`Current issue labels: ${issue.labels.join(' ')}`)

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -106,6 +106,16 @@ export class Commands {
 			return command.type === 'label' && this.action.label === command.name
 		}
 
+		// If the command is a label and the issue has the label, execute the command
+		if (command.type === 'label' && issue.labels.includes(command.name)) {
+			console.debug(
+				`Command ${command.type} matched the issue ${issue.number} and has the label ${
+					command.name
+				}. All labels: ${issue.labels.join(' ')}`,
+			)
+			return true
+		}
+
 		return false
 	}
 


### PR DESCRIPTION
### What changed?

Modifies the logic in the issue commands action to execute all the addToProject
with labels that the issue currently has.

Because github executes this action for each label, it is possible that if an issue
is assigned multiple labels, one of the pipelines will fail because of consecutive runs
and rate limits.

This is a way go guarantee the projects will be correctly assigned since there's no
error or problem at instructing github to assign an issue to a project that is already
assigned.

### Why don't we do this with all the other commands?

The other commands execute actions that are supposed to be a 'one-time' action, e.g.: add a comment
or close the issue.

If we execute these actions on each pipeline run merely because the issue has a label, we will
be executing the same action multiple times e.g. commenting the same twice or more for each label added to an issue

### Is this the best solution?

No. the best solution is to prevent rate limits by using a dedicated github app for this action.
We are working on creating a custom github app for this purpose and this will be here to guarantee
tghe addToProject action works while we test the new app and rate limits.
