### PR TITLE
Note that org members permissions are necessary

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -2,7 +2,10 @@ name: Backport
 description: Automatically creates a cherry pick PR
 inputs:
   token:
-    description: GitHub token with issue, comment, and label read/write permissions
+    description: |
+      GitHub token with read and write permissions for issues, comments, and labels.
+
+      Additionally, the token needs read permissions for organization members. 
     default: ${{ github.token }}
   title:
     description: Title for the backport PR


### PR DESCRIPTION
Used for unassigning default reviewers. If you don't have it, you get cryptic comments posted back on the PR after the backport PRs are opened with the message `Validation Failed: "Could not resolve to a node with the global id of '<NODE ID>."`

Like in https://github.com/grafana/pyroscope/pull/3557#issuecomment-2348613956

