### PR TITLE
Add configuration to opt out of removal of default reviewers

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: |
       GitHub token with read and write permissions for issues, comments, and labels.
 
-      Additionally, the token needs read permissions for organization members. 
+      Additionally, the token needs read permissions for organization members if `removeDefaultReviewers` is set to `true`.
     default: ${{ github.token }}
   title:
     description: Title for the backport PR
@@ -13,6 +13,10 @@ inputs:
   labelsToAdd:
     description: Comma separated list of labels to add to the backport PR.
     required: false
+  removeDefaultReviewers:
+    default: true
+    description: Whether to remove default reviewers from the backport PRs.
+    type: boolean
   metricsWriteAPIKey:
     description: Grfanaa Cloud metrics api key
     required: false

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -4,8 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.backport = exports.getFailedBackportCommentBody = exports.isBettererConflict = exports.LABEL_NO_CHANGELOG = exports.LABEL_ADD_TO_CHANGELOG = exports.BETTERER_RESULTS_PATH = void 0;
-exports.getFinalLabels = getFinalLabels;
+exports.backport = exports.getFinalLabels = exports.getFailedBackportCommentBody = exports.isBettererConflict = exports.LABEL_NO_CHANGELOG = exports.LABEL_ADD_TO_CHANGELOG = exports.BETTERER_RESULTS_PATH = void 0;
 const core_1 = require("@actions/core");
 const exec_1 = require("@actions/exec");
 const github_1 = require("@actions/github");
@@ -389,4 +388,5 @@ function getFinalLabels(originalLabels, labelsToAdd) {
     }
     return result;
 }
+exports.getFinalLabels = getFinalLabels;
 //# sourceMappingURL=backport.js.map

--- a/backport/index.js
+++ b/backport/index.js
@@ -24,6 +24,7 @@ class Backport extends Action_1.Action {
                 labelsToAdd: (0, exports.getLabelsToAdd)((0, core_1.getInput)('labelsToAdd')),
                 payload: github_1.context.payload,
                 titleTemplate: (0, core_1.getInput)('title'),
+                removeDefaultReviewers: (0, core_1.getBooleanInput)('removeDefaultReviewers'),
                 github: issue.octokit,
                 token: this.getToken(),
                 sender: github_1.context.payload.sender,

--- a/backport/index.ts
+++ b/backport/index.ts
@@ -1,4 +1,4 @@
-import { error as logError, getInput, setFailed } from '@actions/core'
+import { error as logError, getBooleanInput, getInput, setFailed } from '@actions/core'
 import { context } from '@actions/github'
 import { EventPayloads } from '@octokit/webhooks'
 import { OctoKitIssue } from '../api/octokit'
@@ -23,6 +23,7 @@ class Backport extends Action {
 				labelsToAdd: getLabelsToAdd(getInput('labelsToAdd')),
 				payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
 				titleTemplate: getInput('title'),
+				removeDefaultReviewers: getBooleanInput('removeDefaultReviewers'),
 				github: issue.octokit,
 				token: this.getToken(),
 				sender: context.payload.sender as EventPayloads.PayloadSender,


### PR DESCRIPTION
It requires extra permissions that can't be satisfied by the default `GITHUB_TOKEN`. By making it configurable, teams can choose to use the default token and sacrifice this feature, or use a GitHub App if they want it.