### PR TITLE
Support adding to project for changed files

### DIFF
--- a/commands/Commands.js
+++ b/commands/Commands.js
@@ -143,7 +143,7 @@ class Commands {
         if (command.action === 'addToProject' &&
             command.addToProject &&
             command.addToProject.url &&
-            issue.labels.includes(command.name)) {
+            (command.name === 'changedfiles' || issue.labels.includes(command.name))) {
             const projectId = (0, utils_1.getProjectIdFromUrl)(command.addToProject.url);
             if (projectId) {
                 tasks.push(this.github.addIssueToProject(projectId, issue, command.addToProject.org, command.addToProject.column));

--- a/commands/Commands.ts
+++ b/commands/Commands.ts
@@ -201,7 +201,7 @@ export class Commands {
 			command.action === 'addToProject' &&
 			command.addToProject &&
 			command.addToProject.url &&
-			issue.labels.includes(command.name)
+			(command.name === 'changedfiles' || issue.labels.includes(command.name))
 		) {
 			const projectId = getProjectIdFromUrl(command.addToProject.url)
 			if (projectId) {


### PR DESCRIPTION
This change allows the `changedFiles` event to be used with the `addToProject` command without checking for a label.