### PR TITLE
CrowdinDownload: Get PR automation secrets from common

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -38,10 +38,9 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
         with:
           # Vault secret paths:
-          # - ci/common/grafana/grafana_frontend_platform_crowdin_bot
+          # - ci/common/grafana/...
           common_secrets: |
             CROWDIN_TOKEN=grafana/grafana_frontend_platform_crowdin_bot:access_token
-          repo_secrets: |
             GRAFANA_PR_AUTOMATION_APP_ID=grafana_pr_automation_app:app_id
             GRAFANA_PR_AUTOMATION_APP_PEM=grafana_pr_automation_app:app_pem
 


### PR DESCRIPTION
To make this workflow work in other repos, we're moving the PR Automation Github App secrets into common. This will be used in other plugin repos.

Part of https://github.com/grafana/grafana/issues/106703