### PR TITLE
Add actionlint Docker wrapper action

### DIFF
--- a/actionlint/action.yml
+++ b/actionlint/action.yml
@@ -1,0 +1,11 @@
+name: actionlint
+description: Lint GitHub Actions workflow files using rhysd/actionlint
+inputs:
+  args:
+    description: Arguments to pass to actionlint
+    default: ''
+runs:
+  using: docker
+  image: docker://rhysd/actionlint:1.7.11@sha256:6f03470d0152251d7f07f7c4dc019dbe7024c72cd952f839544c7798843efa8f
+  args:
+    - ${{ inputs.args }}


### PR DESCRIPTION
## Summary

- Adds `actionlint/action.yml` that wraps the `rhysd/actionlint` Docker image as a reusable GitHub Action
- Allows workflows to reference `grafana/grafana-github-actions/actionlint@SHA` instead of `docker://` references, which are incompatible with org-level action allowlist policies

## Usage

```yaml
- name: Lint workflows
  uses: grafana/grafana-github-actions/actionlint@<commit-sha>
  with:
    args: -color
```