### PR TITLE
Fix gha-otel-export test module resolution

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
 		'^.+\\.(ts|tsx|js|jsx)$': 'ts-jest',
 	},
 	moduleDirectories: ['node_modules'],
+	moduleNameMapper: {
+		'^(\\.{1,2}/.*)\\.js$': '$1',
+	},
 	testRegex: '(\\.|/)(test)\\.(jsx?|tsx?)$',
 	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
 	globals: { 'ts-jest': { isolatedModules: true } },


### PR DESCRIPTION
## Summary

- Adds `moduleNameMapper` to `jest.config.js` to strip `.js` extensions from imports
- Fixes the `trace-ids.test.ts` failure introduced by the `gha-otel-export` package, which uses `NodeNext` module resolution (requires `.js` extensions in imports that ts-jest couldn't resolve)

## Test plan

- [x] `npx jest gha-otel-export/src/trace-ids.test.ts` passes locally