### PR TITLE
Chore: update crowdin workflow

### DIFF
--- a/.github/workflows/crowdin-create-project.yml
+++ b/.github/workflows/crowdin-create-project.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 jobs:
-  create-tasks-in-crowdin:
+  create-project-in-crowdin:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/scripts/crowdin/create-tasks.ts
+++ b/.github/workflows/scripts/crowdin/create-tasks.ts
@@ -1,6 +1,6 @@
 import crowdinImport from '@crowdin/crowdin-api-client';
 const TRANSLATED_CONNECTOR_DESCRIPTION = '{{tos_service_type: premium}}';
-const TRANSLATE_BY_VENDOR_WORKFLOW_TYPE = 'TranslateByVendor'
+const TRANSLATE_BY_VENDOR_WORKFLOW_TYPE = 'Translate'
 
 // TODO Remove this type assertion when https://github.com/crowdin/crowdin-api-client-js/issues/508 is fixed
 // @ts-expect-error


### PR DESCRIPTION
- updates `crowdin-create-tasks` to reference the new node type
- updates `crowdin-create-project` to fix a confusing copy-pasta error