### PR TITLE
Rename package name to grafana-github-actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "vscode-github-triage-actions",
+	"name": "grafana-github-actions",
 	"version": "1.0.0",
 	"private": true,
-	"description": "GitHub Actions used by VS Code for triaging issues",
+	"description": "GitHub Actions used by Grafana for triaging issues",
 	"scripts": {
 		"test": "jest --silent",
 		"build": "tsc",
@@ -11,15 +11,15 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/microsoft/vscode-github-triage-actions.git"
+		"url": "git+https://github.com/microsoft/grafana-github-actions.git"
 	},
 	"keywords": [],
 	"author": "",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/microsoft/vscode-github-triage-actions/issues"
+		"url": "https://github.com/microsoft/grafana-github-actions/issues"
 	},
-	"homepage": "https://github.com/microsoft/vscode-github-triage-actions#readme",
+	"homepage": "https://github.com/microsoft/grafana-github-actions#readme",
 	"dependencies": {
 		"@actions/core": "^1.6.0",
 		"@actions/exec": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/microsoft/grafana-github-actions.git"
+		"url": "git+https://github.com/grafana/grafana-github-actions.git"
 	},
 	"keywords": [],
 	"author": "",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/microsoft/grafana-github-actions/issues"
+		"url": "https://github.com/grafana/grafana-github-actions/issues"
 	},
-	"homepage": "https://github.com/microsoft/grafana-github-actions#readme",
+	"homepage": "https://github.com/grafana/grafana-github-actions#readme",
 	"dependencies": {
 		"@actions/core": "^1.6.0",
 		"@actions/exec": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3529,6 +3529,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"grafana-github-actions@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "grafana-github-actions@workspace:."
+  dependencies:
+    "@actions/core": ^1.6.0
+    "@actions/exec": ^1.1.0
+    "@actions/github": ^2.1.1
+    "@betterer/betterer": ^5.3.7
+    "@crowdin/crowdin-api-client": ^1.42.0
+    "@octokit/graphql": ^4.8.0
+    "@octokit/request-error": ^2.1.0
+    "@octokit/webhooks": ^7.12.2
+    "@types/chai": ^4.2.10
+    "@types/jest": ^27.4.0
+    "@types/lodash.escaperegexp": ^4.1.9
+    "@types/micromatch": ^4.0.1
+    "@types/node": ^20.9.2
+    "@types/semver": ^7.5.6
+    "@types/yargs": ^17.0.32
+    "@typescript-eslint/eslint-plugin": ^6.19.0
+    "@typescript-eslint/parser": ^6.19.0
+    axios: ^0.19.2
+    chai: ^4.2.0
+    dotenv: ^8.2.0
+    eslint: ^8.4.1
+    eslint-config-prettier: ^8.3.0
+    eslint-plugin-prettier: ^4.0.0
+    husky: ^4.2.3
+    jest: ^27.4
+    lodash: ^4.17.20
+    lodash.escaperegexp: ^4.1.2
+    micromatch: ^4.0.2
+    mock-fs: ^5.1.2
+    prettier: 2.5.1
+    semver: ^7.5.4
+    ts-jest: ^27.1.3
+    ts-node: ^8.10.2
+    typescript: ^4.7.2
+    yargs: ^17.7.2
+  languageName: unknown
+  linkType: soft
+
 "graphemer@npm:^1.4.0":
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
@@ -6336,48 +6378,6 @@ __metadata:
   checksum: 54ce92bec2727879626f623d02c8d193f0c7e919941fa373ec135189a8382265117f5316ea317a1e12a5f9c13d84d8449052a731fe3306fa4beaafbfa4cab229
   languageName: node
   linkType: hard
-
-"vscode-github-triage-actions@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "vscode-github-triage-actions@workspace:."
-  dependencies:
-    "@actions/core": ^1.6.0
-    "@actions/exec": ^1.1.0
-    "@actions/github": ^2.1.1
-    "@betterer/betterer": ^5.3.7
-    "@crowdin/crowdin-api-client": ^1.42.0
-    "@octokit/graphql": ^4.8.0
-    "@octokit/request-error": ^2.1.0
-    "@octokit/webhooks": ^7.12.2
-    "@types/chai": ^4.2.10
-    "@types/jest": ^27.4.0
-    "@types/lodash.escaperegexp": ^4.1.9
-    "@types/micromatch": ^4.0.1
-    "@types/node": ^20.9.2
-    "@types/semver": ^7.5.6
-    "@types/yargs": ^17.0.32
-    "@typescript-eslint/eslint-plugin": ^6.19.0
-    "@typescript-eslint/parser": ^6.19.0
-    axios: ^0.19.2
-    chai: ^4.2.0
-    dotenv: ^8.2.0
-    eslint: ^8.4.1
-    eslint-config-prettier: ^8.3.0
-    eslint-plugin-prettier: ^4.0.0
-    husky: ^4.2.3
-    jest: ^27.4
-    lodash: ^4.17.20
-    lodash.escaperegexp: ^4.1.2
-    micromatch: ^4.0.2
-    mock-fs: ^5.1.2
-    prettier: 2.5.1
-    semver: ^7.5.4
-    ts-jest: ^27.1.3
-    ts-node: ^8.10.2
-    typescript: ^4.7.2
-    yargs: ^17.7.2
-  languageName: unknown
-  linkType: soft
 
 "w3c-hr-time@npm:^1.0.2":
   version: 1.0.2


### PR DESCRIPTION
Renames the project name in package.json to grafana-github-actions to reflect that this is actually for grafana, and to make error messages less confusing by not mentioning vscode