### PR TITLE
security: disable postinstall/lifecycle scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,4 @@ enableTelemetry: false
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.11.0.cjs
+enableScripts: false


### PR DESCRIPTION
## Why
Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during
`npm install` / `yarn install` and are a common supply-chain attack vector.

## What changed
- `.npmrc` → `ignore-scripts=true`
- `.yarnrc` → `ignore-scripts true`  *(Yarn Classic repos only)*
- `.yarnrc.yml` → `enableScripts: false`  *(Yarn Berry repos only)*

## CI — add these steps after your install command

These packages use postinstall to generate code or set up hooks.
Add the following steps explicitly in your CI workflow:

```yaml
- name: Run post-install steps
  run: |
    npx husky install
```

## References
- [npm docs — ignore-scripts](https://docs.npmjs.com/cli/v10/using-npm/scripts)
- [Yarn Berry — enableScripts](https://yarnpkg.com/configuration/yarnrc#enableScripts)

> Opened automatically by `bulk_disable_scripts.py` — ping #security with questions.
