### PR TITLE
Revert "CI: Use self-hosted runners in i18n/crowdin actions"

### DIFF
--- a/.github/workflows/crowdin-create-project.yml
+++ b/.github/workflows/crowdin-create-project.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   create-project-in-crowdin:
-    runs-on: ubuntu-x86
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/crowdin-create-tasks.yml
+++ b/.github/workflows/crowdin-create-tasks.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   create-tasks-in-crowdin:
-    runs-on: ubuntu-x86
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   download-sources-from-crowdin:
-    runs-on: ubuntu-x86
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write # needed to commit changes into the PR

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   upload-sources-to-crowdin:
     name: Upload sources to Crowdin
-    runs-on: ubuntu-x86
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/verify-i18n.yml
+++ b/.github/workflows/verify-i18n.yml
@@ -6,7 +6,7 @@ permissions: {}
 
 jobs:
     verify-i18n:
-        runs-on: ubuntu-x86
+        runs-on: ubuntu-latest
         permissions:
             contents: read
         steps:


### PR DESCRIPTION
Reverts grafana/grafana-github-actions#274

Appears this causes some issues - will investigate after revert.