### PR TITLE
Migrate Release Guild ownership to GBS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,19 @@
 # As fallback we set grafana-delivery as owner for everything that has no
 # explicit owner in order to make mandatory reviews possible:
-* @grafana/grafana-release-guild
+* @grafana/grafana-backend-services-squad
 
 # Actions explicitly owned by docs-tooling
 /docs-target/ @grafana/docs-tooling
 /has-matching-release-tag/ @grafana/docs-tooling
 
 # Actions explicitly owned by grafana-delivery:
-/backport/ @grafana/grafana-release-guild
-/bump-version/ @grafana/grafana-release-guild
-/close-milestone/ @grafana/grafana-release-guild
-/enterprise-check/ @grafana/grafana-release-guild
-/github-release/ @grafana/grafana-release-guild
-/remove-milestone/ @grafana/grafana-release-guild
-/update-changelog/ @grafana/grafana-release-guild
+/backport/ @grafana/grafana-backend-services-squad
+/bump-version/ @grafana/grafana-backend-services-squad
+/close-milestone/ @grafana/grafana-backend-services-squad
+/enterprise-check/ @grafana/grafana-backend-services-squad
+/github-release/ @grafana/grafana-backend-services-squad
+/remove-milestone/ @grafana/grafana-backend-services-squad
+/update-changelog/ @grafana/grafana-backend-services-squad
 
 # Actions created by specified people:
 /repository-dispatch/ @AgnesToulet

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: "group:grafana-release-guild"
+  owner: "group:grafana-backend-services-squad"
   system: grafana


### PR DESCRIPTION
## Summary

Release Guild was merged into Grafana Backend Services Squad (GBS) at the org level. This PR transfers the remaining ownership references in this repo to `@grafana/grafana-backend-services-squad`.

## Changes

- `.github/CODEOWNERS` — replace 8 `@grafana/grafana-release-guild` entries with `@grafana/grafana-backend-services-squad`
- `catalog-info.yaml` — `owner: "group:grafana-release-guild"` → `"group:grafana-backend-services-squad"`

## Context

Part of a larger migration tracking PRs across the release pipeline repo set. PR 1 (`grafana/grafana` #123494) and PR 2 (`grafana-enterprise` #11811) already merged. PR 3 (`deployment_tools` #570549) is in review.

## Test plan

- [x] CODEOWNERS file parses (verified by GitHub on PR view)
- [ ] After merge: confirm CODEOWNERS routes to GBS members on a follow-up PR