### PR TITLE
fix(backport): failed backport-action should fail GHA step

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -300,6 +300,7 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
     const prLabels = Array.from(getFinalLabels(originalLabels, labelsToAdd).values());
     await (0, git_1.cloneRepo)({ token, owner, repo });
     await (0, git_1.setConfig)('grafana-delivery-bot');
+    const failedTargets = [];
     for (const [base, head] of Object.entries(backportBaseToHead)) {
         const issueHasBody = !!ghIssue.body;
         const bodySuffix = issueHasBody ? `\n\n---\n\n${ghIssue.body}` : '';
@@ -331,6 +332,7 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
             }
             catch (error) {
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error while backporting';
+                failedTargets.push(base);
                 (0, core_1.error)(errorMessage);
                 // Create comment
                 await github.issues.createComment({
@@ -357,6 +359,9 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
                 });
             }
         });
+    }
+    if (failedTargets.length > 0) {
+        throw new Error(`Backport failed for: ${failedTargets.join(', ')}`);
     }
 };
 exports.backport = backport;

--- a/backport/backport.js
+++ b/backport/backport.js
@@ -71,10 +71,8 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
     };
     await git('switch', base);
     await git('switch', '--create', head);
-    try {
-        await git('cherry-pick', '-x', commitToBackport);
-    }
-    catch (error) {
+    const { exitCode: cherryPickExitCode, stderr: cherryPickStderr } = await (0, exec_1.getExecOutput)('git', ['cherry-pick', '-x', commitToBackport], { cwd: repo, ignoreReturnCode: true });
+    if (cherryPickExitCode !== 0) {
         const gitUnmergedPaths = await gitDiffUnmergedPaths();
         if (await (0, exports.isBettererConflict)(gitUnmergedPaths)) {
             try {
@@ -87,7 +85,7 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
         }
         else {
             await git('cherry-pick', '--abort');
-            throw error;
+            throw new Error(`cherry-pick failed:\n${cherryPickStderr.trim()}`);
         }
     }
     await git('push', '--set-upstream', 'origin', head);

--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -152,16 +152,27 @@ describe('backport/error-propagation', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks()
-		// git switch, git switch --create succeed; cherry-pick fails; cherry-pick --abort succeeds
+		// git switch base, git switch --create, git cherry-pick --abort succeed
 		mockExec
 			.mockResolvedValueOnce(0)
 			.mockResolvedValueOnce(0)
-			.mockRejectedValueOnce(new Error('Process failed: /usr/bin/git failed with exit code 1'))
 			.mockResolvedValueOnce(0)
-		mockGetExecOutput.mockResolvedValue({ stdout: 'conflicted-file.ts', stderr: '', exitCode: 1 })
+		// cherry-pick returns non-zero with stderr; diff returns unmerged paths
+		mockGetExecOutput
+			.mockResolvedValueOnce({
+				exitCode: 1,
+				stderr: 'CONFLICT (content): Merge conflict in foo.ts',
+				stdout: '',
+			})
+			.mockResolvedValueOnce({ exitCode: 0, stdout: 'conflicted-file.ts', stderr: '' })
 	})
 
-	test('rejects when cherry-pick fails', async () => {
+	test('rejects with captured git stderr when cherry-pick fails', async () => {
 		await expect(backport(backportArgs)).rejects.toThrow()
+		expect(mockGithub.issues.createComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.stringContaining('CONFLICT (content): Merge conflict in foo.ts'),
+			}),
+		)
 	})
 })

--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -1,9 +1,28 @@
+import { exec, getExecOutput } from '@actions/exec'
 import {
 	BETTERER_RESULTS_PATH,
+	backport,
 	getFinalLabels,
 	isBettererConflict,
 	getFailedBackportCommentBody,
 } from './backport'
+
+jest.mock('@actions/exec')
+jest.mock('@actions/core', () => ({
+	error: jest.fn(),
+	group: (_name: string, fn: () => Promise<unknown>) => fn(),
+	info: jest.fn(),
+	setFailed: jest.fn(),
+}))
+jest.mock('../common/git', () => ({
+	cloneRepo: jest.fn().mockResolvedValue(undefined),
+	setConfig: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('@betterer/betterer', () => ({ betterer: jest.fn() }))
+jest.mock('@actions/github', () => ({
+	context: { payload: { action: 'closed' } },
+	GitHub: jest.fn(),
+}))
 
 const onlyDocsChanges = ['docs/sources/_index.md', 'docs/sources/other.md']
 const onlyBettererChanges = [BETTERER_RESULTS_PATH]
@@ -85,4 +104,64 @@ test('getFailedBackportCommentBody/gh-line-with-body', () => {
 		`gh pr create --title '[v10.0.x] hello world' --body-file - --label 'backport' --label 'no-changelog' --base v10.0.x --milestone 10.0.x --web`,
 	)
 	expect(output).toContain('git push --set-upstream origin backport-123-to-v10.0.x')
+})
+
+describe('backport/error-propagation', () => {
+	const mockExec = exec as jest.MockedFunction<typeof exec>
+	const mockGetExecOutput = getExecOutput as jest.MockedFunction<typeof getExecOutput>
+
+	const mockGithub = {
+		issues: {
+			createComment: jest.fn().mockResolvedValue({}),
+			addLabels: jest.fn().mockResolvedValue({}),
+			removeLabel: jest.fn().mockResolvedValue({}),
+			listMilestonesForRepo: jest.fn().mockResolvedValue({ data: [] }),
+			update: jest.fn().mockResolvedValue({}),
+		},
+		pulls: {
+			create: jest.fn().mockResolvedValue({ data: { number: 1 } }),
+		},
+	}
+
+	const mockIssue = {
+		getIssue: jest.fn().mockResolvedValue({ labels: [], body: null }),
+	}
+
+	const backportArgs = {
+		issue: mockIssue as any,
+		labelsToAdd: [],
+		payload: {
+			action: 'closed',
+			label: { name: '' },
+			pull_request: {
+				labels: [{ name: 'backport v10.0.x' }, { name: 'type/bug' }],
+				merge_commit_sha: 'abc123',
+				merged: true,
+				number: 42,
+				title: 'fix: some fix',
+				merged_by: { login: 'user' },
+			},
+			repository: { name: 'test-repo', owner: { login: 'test-owner' } },
+		} as any,
+		titleTemplate: '[{{base}}] {{originalTitle}}',
+		removeDefaultReviewers: false,
+		github: mockGithub as any,
+		token: 'test-token',
+		sender: { login: 'user' } as any,
+	}
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		// git switch, git switch --create succeed; cherry-pick fails; cherry-pick --abort succeeds
+		mockExec
+			.mockResolvedValueOnce(0)
+			.mockResolvedValueOnce(0)
+			.mockRejectedValueOnce(new Error('Process failed: /usr/bin/git failed with exit code 1'))
+			.mockResolvedValueOnce(0)
+		mockGetExecOutput.mockResolvedValue({ stdout: 'conflicted-file.ts', stderr: '', exitCode: 1 })
+	})
+
+	test('rejects when cherry-pick fails', async () => {
+		await expect(backport(backportArgs)).rejects.toThrow()
+	})
 })

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -423,6 +423,8 @@ const backport = async ({
 	await cloneRepo({ token, owner, repo })
 	await setConfig('grafana-delivery-bot')
 
+	const failedTargets: string[] = []
+
 	for (const [base, head] of Object.entries(backportBaseToHead)) {
 		const issueHasBody = !!ghIssue.body
 		const bodySuffix = issueHasBody ? `\n\n---\n\n${ghIssue.body}` : ''
@@ -457,6 +459,7 @@ const backport = async ({
 			} catch (error) {
 				const errorMessage: string =
 					error instanceof Error ? error.message : 'Unknown error while backporting'
+				failedTargets.push(base)
 				logError(errorMessage)
 
 				// Create comment
@@ -484,6 +487,10 @@ const backport = async ({
 				})
 			}
 		})
+	}
+
+	if (failedTargets.length > 0) {
+		throw new Error(`Backport failed for: ${failedTargets.join(', ')}`)
 	}
 }
 

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -122,9 +122,13 @@ const backportOnce = async ({
 
 	await git('switch', base)
 	await git('switch', '--create', head)
-	try {
-		await git('cherry-pick', '-x', commitToBackport)
-	} catch (error) {
+
+	const { exitCode: cherryPickExitCode, stderr: cherryPickStderr } = await getExecOutput(
+		'git',
+		['cherry-pick', '-x', commitToBackport],
+		{ cwd: repo, ignoreReturnCode: true },
+	)
+	if (cherryPickExitCode !== 0) {
 		const gitUnmergedPaths = await gitDiffUnmergedPaths()
 
 		if (await isBettererConflict(gitUnmergedPaths)) {
@@ -136,7 +140,7 @@ const backportOnce = async ({
 			}
 		} else {
 			await git('cherry-pick', '--abort')
-			throw error
+			throw new Error(`cherry-pick failed:\n${cherryPickStderr.trim()}`)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Written by Claude. Looks sensible but I'm not familiar with the libraries used.

When a backport fails (e.g. `git cherry-pick` exits with code 1), the GHA step was exiting 0 instead of failing. The action posts a failure comment and adds the `backport-failed` label, but the step appeared green in CI.

Root cause: the catch block in the `for` loop in `backport.ts` handled each failure (comment + label) but swallowed the exception without rethrowing, so `setFailed()` was never called.

Fix: track failed targets in a `failedTargets` array; after all targets are attempted, throw if any failed. This tries all backport targets before surfacing the error, and propagates to `index.ts`'s catch which calls `setFailed()`, setting `process.exitCode = 1`. The failure comment and `backport-failed` label behaviour is unchanged.

## Test plan

- [x] `backport/error-propagation › rejects when cherry-pick fails`: fails (resolves) before fix, passes (rejects) after
- [x] Full test suite passes: `yarn jest`