### PR TITLE
fix(release-notes-appender): propagate errors from failed PR creation to fail GHA step

### DIFF
--- a/release-notes-appender/release.js
+++ b/release-notes-appender/release.js
@@ -168,6 +168,7 @@ const release = async ({ labelsToAdd, payload: { pull_request: { labels, merged,
                 owner,
                 repo,
             });
+            throw error;
         }
     });
 };

--- a/release-notes-appender/release.js
+++ b/release-notes-appender/release.js
@@ -13,7 +13,10 @@ const git_1 = require("../common/git");
 const labelMatcher = 'add-to-release-notes';
 const createReleaseNotesPR = async ({ pullRequestNumber: prNumber, pullRequestUrl: prUrl, pullRequestTitle: prTitle, releaseNotesFile, github, head, labelsToAdd, owner, repo, title, milestone, mergedBy, }) => {
     const git = async (...args) => {
-        await (0, exec_1.exec)('git', args, { cwd: repo });
+        const { exitCode, stderr } = await (0, exec_1.getExecOutput)('git', args, { cwd: repo, ignoreReturnCode: true });
+        if (exitCode !== 0) {
+            throw new Error(`git ${args[0]} failed:\n${stderr.trim()}`);
+        }
     };
     await git('checkout', 'main');
     await git('pull');

--- a/release-notes-appender/release.test.ts
+++ b/release-notes-appender/release.test.ts
@@ -1,0 +1,77 @@
+import { exec } from '@actions/exec'
+import { release } from './release'
+
+jest.mock('@actions/exec')
+jest.mock('@actions/core', () => ({
+	error: jest.fn(),
+	group: (_name: string, fn: () => Promise<unknown>) => fn(),
+	info: jest.fn(),
+	setFailed: jest.fn(),
+}))
+jest.mock('../common/git', () => ({
+	cloneRepo: jest.fn().mockResolvedValue(undefined),
+	setConfig: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('./FileAppender', () => ({
+	FileAppender: jest.fn().mockImplementation(() => ({
+		loadFile: jest.fn(),
+		append: jest.fn(),
+		writeFile: jest.fn(),
+	})),
+}))
+jest.mock('@actions/github', () => ({
+	context: {
+		payload: {
+			action: 'closed',
+			pull_request: { html_url: 'https://github.com/grafana/grafana/pull/42' },
+		},
+	},
+	GitHub: jest.fn(),
+}))
+
+describe('release/error-propagation', () => {
+	const mockExec = exec as jest.MockedFunction<typeof exec>
+
+	const mockGithub = {
+		issues: {
+			createComment: jest.fn().mockResolvedValue({}),
+			addLabels: jest.fn().mockResolvedValue({}),
+			update: jest.fn().mockResolvedValue({}),
+		},
+		pulls: {
+			create: jest.fn().mockResolvedValue({ data: { number: 1, requested_reviewers: [] } }),
+			deleteReviewRequest: jest.fn().mockResolvedValue({}),
+			createReviewRequest: jest.fn().mockResolvedValue({}),
+		},
+	}
+
+	const releaseArgs = {
+		labelsToAdd: [],
+		payload: {
+			pull_request: {
+				labels: [{ name: 'add-to-release-notes' }],
+				merged: true,
+				number: 42,
+				title: 'fix: some fix',
+				html_url: 'https://github.com/grafana/grafana/pull/42',
+				milestone: null,
+				merged_by: { login: 'user' },
+			},
+			repository: { name: 'test-repo', owner: { login: 'test-owner' } },
+		} as any,
+		titleTemplate: 'Add {{pullRequestNumber}} to release notes',
+		releaseNotesFile: 'release-notes.md',
+		github: mockGithub as any,
+		token: 'test-token',
+		sender: { login: 'user' } as any,
+	}
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		mockExec.mockRejectedValue(new Error('Process failed: /usr/bin/git failed with exit code 1'))
+	})
+
+	test('rejects when git operation fails', async () => {
+		await expect(release(releaseArgs)).rejects.toThrow()
+	})
+})

--- a/release-notes-appender/release.test.ts
+++ b/release-notes-appender/release.test.ts
@@ -1,4 +1,4 @@
-import { exec } from '@actions/exec'
+import { getExecOutput } from '@actions/exec'
 import { release } from './release'
 
 jest.mock('@actions/exec')
@@ -30,7 +30,7 @@ jest.mock('@actions/github', () => ({
 }))
 
 describe('release/error-propagation', () => {
-	const mockExec = exec as jest.MockedFunction<typeof exec>
+	const mockGetExecOutput = getExecOutput as jest.MockedFunction<typeof getExecOutput>
 
 	const mockGithub = {
 		issues: {
@@ -68,10 +68,21 @@ describe('release/error-propagation', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks()
-		mockExec.mockRejectedValue(new Error('Process failed: /usr/bin/git failed with exit code 1'))
+		mockGetExecOutput.mockResolvedValue({
+			exitCode: 1,
+			stderr: 'error: pathspec \'main\' did not match any file(s) known to git',
+			stdout: '',
+		})
 	})
 
-	test('rejects when git operation fails', async () => {
+	test('rejects with captured git stderr when git operation fails', async () => {
 		await expect(release(releaseArgs)).rejects.toThrow()
+		expect(mockGithub.issues.createComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.stringContaining(
+					"error: pathspec 'main' did not match any file(s) known to git",
+				),
+			}),
+		)
 	})
 })

--- a/release-notes-appender/release.ts
+++ b/release-notes-appender/release.ts
@@ -255,6 +255,7 @@ const release = async ({
 				owner,
 				repo,
 			})
+			throw error
 		}
 	})
 }

--- a/release-notes-appender/release.ts
+++ b/release-notes-appender/release.ts
@@ -1,7 +1,7 @@
 import { EventPayloads } from '@octokit/webhooks'
 import { context, GitHub } from '@actions/github'
 import { error as logError, group } from '@actions/core'
-import { exec } from '@actions/exec'
+import { getExecOutput } from '@actions/exec'
 import escapeRegExp from 'lodash.escaperegexp'
 
 import { FileAppender } from './FileAppender'
@@ -37,7 +37,10 @@ const createReleaseNotesPR = async ({
 	mergedBy: any
 }) => {
 	const git = async (...args: string[]) => {
-		await exec('git', args, { cwd: repo })
+		const { exitCode, stderr } = await getExecOutput('git', args, { cwd: repo, ignoreReturnCode: true })
+		if (exitCode !== 0) {
+			throw new Error(`git ${args[0]} failed:\n${stderr.trim()}`)
+		}
 	}
 
 	await git('checkout', 'main')


### PR DESCRIPTION
## Summary

Written by Claude. Looks sensible but I'm not familiar with the libraries used.

Closes: https://github.com/grafana/grafana-github-actions/issues/165

When release-notes-appender fails (e.g. a git operation exits with a non-zero code), the GHA step was exiting 0 instead of failing. The action posts a failure comment and adds the `release-notes-failed` label, but the step appeared green in CI.

Root cause: the catch block in `release.ts` handled the failure (comment + label) but swallowed the exception without rethrowing, so `setFailed()` was never called.

Fix: rethrow after the failure comment and label are posted. This propagates to `index.ts`'s catch which calls `setFailed()`, setting `process.exitCode = 1`. The failure comment and `release-notes-failed` label behaviour is unchanged.

## Test plan

- [x] `release/error-propagation › rejects when git operation fails`: fails (resolves) before fix, passes (rejects) after
- [x] Full test suite passes: `yarn jest`