### PR TITLE
backport: sign commits by publishing via the GitHub GraphQL API

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -4,13 +4,62 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.backport = exports.getFinalLabels = exports.getFailedBackportCommentBody = exports.isBettererConflict = exports.LABEL_NO_CHANGELOG = exports.LABEL_ADD_TO_CHANGELOG = exports.BETTERER_RESULTS_PATH = void 0;
+exports.backport = exports.getFinalLabels = exports.getFailedBackportCommentBody = exports.isBettererConflict = exports.LABEL_NO_CHANGELOG = exports.LABEL_ADD_TO_CHANGELOG = exports.BETTERER_RESULTS_PATH = exports.buildFileChanges = void 0;
 const core_1 = require("@actions/core");
 const exec_1 = require("@actions/exec");
 const github_1 = require("@actions/github");
 const betterer_1 = require("@betterer/betterer");
+const graphql_1 = require("@octokit/graphql");
+const fs_1 = require("fs");
 const lodash_escaperegexp_1 = __importDefault(require("lodash.escaperegexp"));
+const path_1 = __importDefault(require("path"));
 const git_1 = require("../common/git");
+// Build the FileChanges payload for createCommitOnBranch from the diff between two refs in a
+// local git checkout. Renames are not represented separately by createCommitOnBranch, so we
+// pass --no-renames to git and let renamed files appear as a deletion + addition.
+async function buildFileChanges(repoDir, fromRef, toRef) {
+    const { stdout } = await (0, exec_1.getExecOutput)('git', ['diff', '--no-renames', '--name-status', '-z', fromRef, toRef], { cwd: repoDir, silent: true });
+    const additions = [];
+    const deletions = [];
+    // `git diff -z --name-status` emits NUL-separated tokens, alternating "<status>" and
+    // "<path>". With --no-renames there are no rename/copy triples to worry about.
+    const tokens = stdout.split('\0').filter((t) => t.length > 0);
+    for (let i = 0; i + 1 < tokens.length; i += 2) {
+        const status = tokens[i][0];
+        const filePath = tokens[i + 1];
+        if (status === 'D') {
+            deletions.push({ path: filePath });
+        }
+        else {
+            // A (added), M (modified), T (type change) — read the new content.
+            const buf = await fs_1.promises.readFile(path_1.default.join(repoDir, filePath));
+            additions.push({ path: filePath, contents: buf.toString('base64') });
+        }
+    }
+    return { additions, deletions };
+}
+exports.buildFileChanges = buildFileChanges;
+const createCommitOnBranchMutation = `
+  mutation(
+    $repo: String!
+    $branch: String!
+    $oid: GitObjectID!
+    $message: String!
+    $additions: [FileAddition!]
+    $deletions: [FileDeletion!]
+  ) {
+    createCommitOnBranch(
+      input: {
+        branch: { repositoryNameWithOwner: $repo, branchName: $branch }
+        expectedHeadOid: $oid
+        fileChanges: { additions: $additions, deletions: $deletions }
+        message: { headline: $message }
+      }
+    ) {
+      commit { url oid }
+    }
+  }
+`;
 exports.BETTERER_RESULTS_PATH = '.betterer.results';
 exports.LABEL_ADD_TO_CHANGELOG = 'add to changelog';
 exports.LABEL_NO_CHANGELOG = 'no-changelog';
@@ -53,9 +102,13 @@ const isBettererConflict = async (gitUnmergedPaths) => {
     return gitUnmergedPaths.length === 1 && gitUnmergedPaths[0] === exports.BETTERER_RESULTS_PATH;
 };
 exports.isBettererConflict = isBettererConflict;
-const backportOnce = async ({ base, body, commitToBackport, github, head, labelsToAdd, removeDefaultReviewers, owner, repo, title, mergedBy, }) => {
+const backportOnce = async ({ base, body, commitToBackport, github, head, labelsToAdd, removeDefaultReviewers, owner, repo, title, mergedBy, token, }) => {
     const git = async (...args) => {
         await (0, exec_1.exec)('git', args, { cwd: repo });
+    };
+    const gitOutput = async (...args) => {
+        const { stdout } = await (0, exec_1.getExecOutput)('git', args, { cwd: repo, silent: true });
+        return stdout.trim();
     };
     const gitDiffUnmergedPaths = async () => {
         const { stdout } = await (0, exec_1.getExecOutput)('git', ['diff', '--name-only', '--diff-filter=U'], {
@@ -70,6 +123,7 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
         await git('-c', 'core.editor=true', 'cherry-pick', '--continue');
     };
     await git('switch', base);
+    const baseSha = await gitOutput('rev-parse', 'HEAD');
     await git('switch', '--create', head);
     try {
         await git('cherry-pick', '-x', commitToBackport);
@@ -90,7 +144,26 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
             throw error;
         }
     }
-    await git('push', '--set-upstream', 'origin', head);
+    // Publish the cherry-picked commit via the GraphQL createCommitOnBranch mutation so that the
+    // resulting commit is signed by GitHub's web-flow key (shows as Verified) instead of an
+    // unsigned `git push`. The original author is preserved via a Co-authored-by trailer, since
+    // the API uses the authenticated identity (typically a GitHub App) as the author/committer.
+    const fileChanges = await buildFileChanges(repo, baseSha, 'HEAD');
+    const commitMessage = await gitOutput('log', '-1', '--format=%B', 'HEAD');
+    const originalAuthorName = await gitOutput('log', '-1', '--format=%an', commitToBackport);
+    const originalAuthorEmail = await gitOutput('log', '-1', '--format=%ae', commitToBackport);
+    const message = commitMessage.replace(/\s+$/, '') +
+        `\n\nCo-authored-by: ${originalAuthorName} <${originalAuthorEmail}>`;
+    await github.git.createRef({ owner, repo, ref: `refs/heads/${head}`, sha: baseSha });
+    const authedGraphQL = graphql_1.graphql.defaults({ headers: { authorization: `token ${token}` } });
+    await authedGraphQL(createCommitOnBranchMutation, {
+        repo: `${owner}/${repo}`,
+        branch: head,
+        oid: baseSha,
+        message,
+        additions: fileChanges.additions,
+        deletions: fileChanges.deletions,
+    });
     const createRsp = await github.pulls.create({
         base,
         body,
@@ -327,6 +400,7 @@ const backport = async ({ issue, labelsToAdd, payload: { action, label, pull_req
                     repo,
                     title,
                     mergedBy: merged_by,
+                    token,
                 });
             }
             catch (error) {

--- a/backport/backport.test.ts
+++ b/backport/backport.test.ts
@@ -1,5 +1,10 @@
+import { exec, getExecOutput } from '@actions/exec'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
 import {
 	BETTERER_RESULTS_PATH,
+	buildFileChanges,
 	getFinalLabels,
 	isBettererConflict,
 	getFailedBackportCommentBody,
@@ -68,6 +73,58 @@ test('getFailedBackportCommentBody/gh-line-no-body', () => {
 		`gh pr create --title '[v10.0.x] hello world' --body 'Backport 123456 from #123' --label 'backport' --base v10.0.x --milestone 10.0.x --web`,
 	)
 	expect(output).toContain('git push --set-upstream origin backport-123-to-v10.0.x')
+})
+
+describe('buildFileChanges', () => {
+	let repoDir: string
+
+	const gitInit = async () => {
+		await exec('git', ['init', '-q', '-b', 'main'], { cwd: repoDir, silent: true })
+		await exec('git', ['config', 'user.email', 't@example.com'], { cwd: repoDir, silent: true })
+		await exec('git', ['config', 'user.name', 't'], { cwd: repoDir, silent: true })
+		await exec('git', ['config', 'commit.gpgsign', 'false'], { cwd: repoDir, silent: true })
+	}
+
+	beforeEach(async () => {
+		repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'backport-test-'))
+		await gitInit()
+	})
+
+	afterEach(async () => {
+		await fs.rm(repoDir, { recursive: true, force: true })
+	})
+
+	test('detects additions, modifications and deletions', async () => {
+		// Base state: keep.txt and del.txt exist with known content.
+		await fs.writeFile(path.join(repoDir, 'keep.txt'), 'keep-v1\n')
+		await fs.writeFile(path.join(repoDir, 'del.txt'), 'will be deleted\n')
+		await exec('git', ['add', '.'], { cwd: repoDir, silent: true })
+		await exec('git', ['commit', '-q', '-m', 'base'], { cwd: repoDir, silent: true })
+		const { stdout: baseRaw } = await getExecOutput('git', ['rev-parse', 'HEAD'], {
+			cwd: repoDir,
+			silent: true,
+		})
+		const base = baseRaw.trim()
+
+		// Tip state: modify keep.txt, add new.txt, delete del.txt.
+		await fs.writeFile(path.join(repoDir, 'keep.txt'), 'keep-v2\n')
+		await fs.writeFile(path.join(repoDir, 'new.txt'), 'brand-new\n')
+		await fs.rm(path.join(repoDir, 'del.txt'))
+		await exec('git', ['add', '-A'], { cwd: repoDir, silent: true })
+		await exec('git', ['commit', '-q', '-m', 'tip'], { cwd: repoDir, silent: true })
+
+		const changes = await buildFileChanges(repoDir, base, 'HEAD')
+
+		const paths = changes.additions.map((a) => a.path).sort()
+		expect(paths).toEqual(['keep.txt', 'new.txt'])
+
+		const decoded = (p: string) =>
+			Buffer.from(changes.additions.find((a) => a.path === p)!.contents, 'base64').toString()
+		expect(decoded('keep.txt')).toBe('keep-v2\n')
+		expect(decoded('new.txt')).toBe('brand-new\n')
+
+		expect(changes.deletions).toEqual([{ path: 'del.txt' }])
+	})
 })
 
 test('getFailedBackportCommentBody/gh-line-with-body', () => {

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -4,10 +4,77 @@ import { error as logError, group, info } from '@actions/core'
 import { exec, getExecOutput } from '@actions/exec'
 import { context, GitHub } from '@actions/github'
 import { betterer } from '@betterer/betterer'
+import { graphql } from '@octokit/graphql'
 import { EventPayloads } from '@octokit/webhooks'
+import { promises as fs } from 'fs'
 import escapeRegExp from 'lodash.escaperegexp'
+import path from 'path'
 import { cloneRepo, setConfig } from '../common/git'
 import { OctoKitIssue } from '../api/octokit'
+
+export interface FileAddition {
+	path: string
+	contents: string // base64-encoded
+}
+
+export interface FileChanges {
+	additions: FileAddition[]
+	deletions: { path: string }[]
+}
+
+// Build the FileChanges payload for createCommitOnBranch from the diff between two refs in a
+// local git checkout. Renames are not represented separately by createCommitOnBranch, so we
+// pass --no-renames to git and let renamed files appear as a deletion + addition.
+export async function buildFileChanges(
+	repoDir: string,
+	fromRef: string,
+	toRef: string,
+): Promise<FileChanges> {
+	const { stdout } = await getExecOutput(
+		'git',
+		['diff', '--no-renames', '--name-status', '-z', fromRef, toRef],
+		{ cwd: repoDir, silent: true },
+	)
+	const additions: FileAddition[] = []
+	const deletions: { path: string }[] = []
+	// `git diff -z --name-status` emits NUL-separated tokens, alternating "<status>" and
+	// "<path>". With --no-renames there are no rename/copy triples to worry about.
+	const tokens = stdout.split('\0').filter((t) => t.length > 0)
+	for (let i = 0; i + 1 < tokens.length; i += 2) {
+		const status = tokens[i][0]
+		const filePath = tokens[i + 1]
+		if (status === 'D') {
+			deletions.push({ path: filePath })
+		} else {
+			// A (added), M (modified), T (type change) — read the new content.
+			const buf = await fs.readFile(path.join(repoDir, filePath))
+			additions.push({ path: filePath, contents: buf.toString('base64') })
+		}
+	}
+	return { additions, deletions }
+}
+
+const createCommitOnBranchMutation = `
+  mutation(
+    $repo: String!
+    $branch: String!
+    $oid: GitObjectID!
+    $message: String!
+    $additions: [FileAddition!]
+    $deletions: [FileDeletion!]
+  ) {
+    createCommitOnBranch(
+      input: {
+        branch: { repositoryNameWithOwner: $repo, branchName: $branch }
+        expectedHeadOid: $oid
+        fileChanges: { additions: $additions, deletions: $deletions }
+        message: { headline: $message }
+      }
+    ) {
+      commit { url oid }
+    }
+  }
+`
 
 export const BETTERER_RESULTS_PATH = '.betterer.results'
 export const LABEL_ADD_TO_CHANGELOG = 'add to changelog'
@@ -88,6 +155,7 @@ const backportOnce = async ({
 	repo,
 	title,
 	mergedBy,
+	token,
 }: {
 	base: string
 	body: string
@@ -100,9 +168,14 @@ const backportOnce = async ({
 	repo: string
 	title: string
 	mergedBy: any
+	token: string
 }) => {
 	const git = async (...args: string[]) => {
 		await exec('git', args, { cwd: repo })
+	}
+	const gitOutput = async (...args: string[]): Promise<string> => {
+		const { stdout } = await getExecOutput('git', args, { cwd: repo, silent: true })
+		return stdout.trim()
 	}
 
 	const gitDiffUnmergedPaths = async (): Promise<string[]> => {
@@ -121,6 +194,7 @@ const backportOnce = async ({
 	}
 
 	await git('switch', base)
+	const baseSha = await gitOutput('rev-parse', 'HEAD')
 	await git('switch', '--create', head)
 	try {
 		await git('cherry-pick', '-x', commitToBackport)
@@ -140,7 +214,30 @@ const backportOnce = async ({
 		}
 	}
 
-	await git('push', '--set-upstream', 'origin', head)
+	// Publish the cherry-picked commit via the GraphQL createCommitOnBranch mutation so that the
+	// resulting commit is signed by GitHub's web-flow key (shows as Verified) instead of an
+	// unsigned `git push`. The original author is preserved via a Co-authored-by trailer, since
+	// the API uses the authenticated identity (typically a GitHub App) as the author/committer.
+	const fileChanges = await buildFileChanges(repo, baseSha, 'HEAD')
+	const commitMessage = await gitOutput('log', '-1', '--format=%B', 'HEAD')
+	const originalAuthorName = await gitOutput('log', '-1', '--format=%an', commitToBackport)
+	const originalAuthorEmail = await gitOutput('log', '-1', '--format=%ae', commitToBackport)
+	const message =
+		commitMessage.replace(/\s+$/, '') +
+		`\n\nCo-authored-by: ${originalAuthorName} <${originalAuthorEmail}>`
+
+	await github.git.createRef({ owner, repo, ref: `refs/heads/${head}`, sha: baseSha })
+
+	const authedGraphQL = graphql.defaults({ headers: { authorization: `token ${token}` } })
+	await authedGraphQL(createCommitOnBranchMutation, {
+		repo: `${owner}/${repo}`,
+		branch: head,
+		oid: baseSha,
+		message,
+		additions: fileChanges.additions,
+		deletions: fileChanges.deletions,
+	})
+
 	const createRsp = await github.pulls.create({
 		base,
 		body,
@@ -453,6 +550,7 @@ const backport = async ({
 					repo,
 					title,
 					mergedBy: merged_by,
+					token,
 				})
 			} catch (error) {
 				const errorMessage: string =


### PR DESCRIPTION
## Summary

Replace the unsigned `git push --set-upstream origin <head>` in the `backport` action with a `createCommitOnBranch` GraphQL mutation. The cherry-pick still runs locally (preserving the conflict-resolution logic and the betterer fallback), but the resulting commit is published to the new branch via the GitHub API, so it is signed by GitHub's web-flow key and shows as **Verified** in the UI.

## Why

The backport action is consumed by Grafana repos whose CI flows run from GitHub Apps. Apps can't have GPG/SSH signing keys registered against them, so `git push` from the runner produces an unsigned commit. This is friction wherever signed commits are part of the audit/provenance story for a repository.

The fix is server-side: GitHub's `createCommitOnBranch` mutation signs commits with the web-flow key automatically — the same mechanism the "Merge pull request" button uses.

## How

In `backport/backport.ts`:

1. After `git switch base`, capture the base SHA via `git rev-parse HEAD`.
2. Run the cherry-pick exactly as before (preserving the existing conflict + betterer handling). This produces a local commit on the working branch with the right tree.
3. Build a `FileChanges` payload by diffing base → HEAD with `git diff --no-renames --name-status -z`:
   - `D` → `deletions[{ path }]`.
   - `A` / `M` / `T` → `additions[{ path, contents (base64 of file bytes) }]`.
4. Create the head branch on GitHub via `github.git.createRef`.
5. Call `createCommitOnBranch` via `@octokit/graphql` (already a transitive dependency) with the file changes and the cherry-pick's commit message. The original author of `commitToBackport` is preserved as a `Co-authored-by:` trailer so attribution survives.
6. Continue with the existing `github.pulls.create()` etc.

The local `git push --set-upstream` is removed.

## Trade-offs

- **Author / committer identity**: with this change, the GitHub App running the action becomes both the author and committer of the resulting commit. Today the cherry-pick preserves the original author in the `author:` field. Attribution is recovered via the `Co-authored-by:` trailer added to the commit message — GitHub renders co-authors with avatars in the commit view.
- **"Partially verified" UI badge**: GitHub's UI shows "Partially verified" on signed commits that carry a `Co-authored-by:` trailer, because the signature attests the API call but not the co-author claim. The API still returns `verification.verified: true` / `reason: valid`, which is what branch-protection "Require signed commits" rules check — confirmed by enabling the rule on a sandbox `release-1.0` branch and successfully merging a backport PR whose commit had the "Partially verified" badge.
- **File mode changes** (e.g. executable bit, type changes between regular file/symlink) are not preserved, because `createCommitOnBranch`'s `FileAddition` input doesn't accept a mode. Most backports don't touch modes; flagging here for completeness.
- **Renames** are flattened into delete-plus-add by passing `--no-renames` to `git diff`. The diff content reaching the destination branch is identical, only the visual rendering on GitHub differs.

## Tests

- All existing tests pass.
- Added `backport/backport.test.ts` coverage for the new `buildFileChanges` helper, exercising additions, modifications, and deletions against a temp git repo.

## Compiled JS

`backport/backport.js` is regenerated and committed alongside the TS, matching the repo's convention.

## Test plan

Tested end-to-end in https://github.com/pracucci/backport-test (sandbox, no secrets):

1. **Sandbox set up** with GHA PR creation enabled (otherwise `github.pulls.create()` fails with `not permitted to create or approve pull requests`): `gh api repos/pracucci/backport-test/actions/permissions/workflow -X PUT -F can_approve_pull_request_reviews=true -F default_workflow_permissions=write`.
2. **Caller workflow added** at `.github/workflows/backport.yml` triggered on `pull_request: [closed, labeled]`; checks out this PR's branch at ref `ce15900ea5af59b4af848d268b33438c0693f10b` into `./actions`, installs deps via `corepack enable && yarn install --immutable` (the project enforces `engine-strict=true` against npm), then runs `./actions/backport` with `token: ${{ secrets.GITHUB_TOKEN }}`.
3. **`release-1.0` branch** created off `main` as the backport target.
4. **Test PR #7 opened** (`feature-7 → main`) adding a new file `docs/feature-7.md` — new files avoid the cherry-pick conflicts you get from modifying files that have diverged.
5. **Both labels applied via REST** (`backport release-1.0` + `type/bug`) using `gh api .../issues/7/labels --method POST --input -`. The action gates on both: a `backport <branch>` label AND a category label (`type/bug` / `type/docs` / `type/ci` / `product-approved`). `gh pr edit --add-label` currently silently no-ops due to a Projects-classic GraphQL deprecation error in the CLI.
6. **PR merged** with `gh pr merge 7 --squash`, firing `closed` with `merged: true` → action ran.
7. **Backport commit verified** at https://github.com/pracucci/backport-test/commit/23eb752bc2 on `backport-7-to-release-1.0`: `verification.verified: true`, `reason: valid`; committer `GitHub`, author `github-actions[bot]`; message `Add Feature 7 doc (#7)\n\n(cherry picked from commit 9f00f5a6e3…)\n\nCo-authored-by: Marco Pracucci <marco@grafana.com>` — cherry-pick attribution + Co-authored-by trailer both intact; only `docs/feature-7.md` modified.
8. **Backport PR verified** at https://github.com/pracucci/backport-test/pull/8 (`[release-1.0] Add Feature 7 doc`) with the original PR's `type/bug` label plus `backport` carried over.
9. **Branch protection compatibility verified**: enabled "Require signed commits" on `release-1.0` and merged PR #8 — succeeded, so a UI-"Partially verified" backport commit is accepted by the rule (it's `verification.verified: true` at the API level).

### Findings during testing

- **npm install fails with `EBADENGINE`** — `.npmrc` has `engine-strict=true` and `package.json` declares `engines.npm: please-use-yarn`. Consumers pinning to this branch (or anything newer than the npm-blocker) must switch their caller workflow from `npm install` to `corepack enable && yarn install --immutable`.
- **First cherry-pick attempt conflicted** because the test PR modified `README.md` which had diverged on `main`. Use new files for backport tests; same caveat applies to any cherry-pick on a divergent branch.
- **First fully-API-driven run** failed at `github.pulls.create()` with `not permitted to create or approve pull requests` (a repo-level setting). The branch + Verified commit were created successfully **before** the failure (https://github.com/pracucci/backport-test/commit/90785ef76d), so the signing-related code paths in this PR were already exercised. Enabling the permission setting let the next run complete end-to-end.