### PR TITLE
Crowdin download: look up the existing PR with `gh pr list`

### DIFF
--- a/crowdin-download/action.yaml
+++ b/crowdin-download/action.yaml
@@ -141,7 +141,7 @@ runs:
           if: steps.signed-commit.outputs.has_commit == 'true'
           shell: bash
           run: |
-              PR_URL=$(gh pr view --head i18n_crowdin_translations --json url -q .url 2>/dev/null || true)
+              PR_URL=$(gh pr list --head i18n_crowdin_translations --state open --json url -q '.[0].url' 2>/dev/null || true)
 
               if [ -z "$PR_URL" ]; then
                 cat > /tmp/crowdin-pr-body.md << 'PREOF'


### PR DESCRIPTION
## What

The "create PR" step looks for an existing translation PR with a flag `gh pr view` does not
have:

```bash
PR_URL=$(gh pr view --head i18n_crowdin_translations --json url -q .url 2>/dev/null || true)
```

`gh pr view` takes only `[<number> | <url> | <branch>]` as a positional argument:

```
$ gh pr view --head i18n_crowdin_translations --repo grafana/grafana --json url -q .url
unknown flag: --head
```

The `2>/dev/null || true` swallows that, so `PR_URL` is **always** empty. The
`if [ -z "$PR_URL" ]` guard below therefore always passes and `gh pr create` always runs,
which fails whenever a translation PR is already open:

```
a pull request for branch "i18n_crowdin_translations" into branch "main" already exists:
https://github.com/grafana/grafana/pull/130734
##[error]Process completed with exit code 1.
```

## The pattern this explains

`i18n-crowdin-download` in grafana/grafana succeeds and fails in runs that track exactly
whether a PR is open on that fixed branch:

| dates | result | state of the branch |
|---|---|---|
| 08-14 to 08-17 | failure | #130734 opened 08-14 and still open |
| 08-11 to 08-13 | success | no open PR |
| 08-08 to 08-10 | failure | a PR was open |
| 08-06 to 08-07 | success | no open PR |

So the daily job only works on days when the previous PR happens to have been merged.

This is long-standing rather than a regression: the same line is present in the blob before
#327, which touched this file but left it unchanged.

## Fix

`gh pr list` does support `--head`, so use it and take the first result:

```bash
PR_URL=$(gh pr list --head i18n_crowdin_translations --state open --json url -q '.[0].url' 2>/dev/null || true)
```

Checked against the live repository, where it returns the PR the old command could not find:

```
$ gh pr list --head i18n_crowdin_translations --state open --repo grafana/grafana --json url -q '.[0].url'
https://github.com/grafana/grafana/pull/130734
```

With that, the guard sees the open PR and the step moves on to the update path instead of
trying to create a duplicate.

## One thing I left alone

Further down, the same script exits non-zero when it decides **not** to auto-approve:

```bash
echo "Non-i18n changes detected, not approving"
exit 1
```

Declining to auto-approve looks like a normal outcome rather than an error, and it marks the
whole scheduled run red even though the PR was created correctly and just needs a human. I
did not change it, since you may be using the red run deliberately as a signal. Happy to
switch those two to `exit 0` in this PR if you would prefer.
